### PR TITLE
Twitter Undocumented Search Parameters

### DIFF
--- a/lib/twitter/search.rb
+++ b/lib/twitter/search.rb
@@ -66,9 +66,29 @@ module Twitter
       self
     end
 
-    # popular|recent
+    # popular|recent|mixed
     def result_type(result_type)
       @query[:result_type] = result_type
+      self
+    end
+    
+    # Filters for tweets with links. Limits query to 7 days.
+    def filter_links
+      @query[:filter] = "links"
+      self
+    end
+    
+    # Specifies which words to OR together.
+    def or(word)
+      @query[:ors] ||= []
+      @query[:ors] << word.to_s
+      self
+    end
+    
+    # Specifies which words to AND together.
+    def and(word)
+      @query[:ands] ||= []
+      @query[:ands] << word.to_s
       self
     end
 

--- a/test/twitter/search_test.rb
+++ b/test/twitter/search_test.rb
@@ -40,6 +40,18 @@ class SearchTest < Test::Unit::TestCase
     should "should be able to specify not to" do
       @search.to('jnunemaker',true).query[:q].should include('-to:jnunemaker')
     end
+    
+    should "should be able to specify AND query" do
+      @search.and('Foobar').query[:ands].should include('Foobar')
+    end
+    
+    should "should be able to specify OR query" do
+      @search.or('Foobar').query[:ors].should include('Foobar')
+    end
+    
+    should "should be able to filter by links" do
+      @search.filter_links.query[:filter].should include('link')
+    end
 
     should "should be able to specify not referencing" do
       @search.referencing('jnunemaker',true).query[:q].should include('-@jnunemaker')


### PR DESCRIPTION
There are two parameters that aren't documented in the developer API but are used on their Advanced Search page: http://search.twitter.com/advanced

They are ors and ands; which you can use to query more efficiently. At one time they documented that you could take the queries from search.twitter.com and use them with .json like the API.  Not sure if that's the case or not.

I also added the filters:link, which has a side effect of limiting the query to only 7 days.
