### PR TITLE
Twitter::Base#user doesn't conform to twitter API

### DIFF
--- a/lib/twitter/base.rb
+++ b/lib/twitter/base.rb
@@ -91,8 +91,13 @@ module Twitter
       perform_get("/#{Twitter.api_version}/statuses/followers.json", :query => query)
     end
 
-    def user(id, query={})
-      perform_get("/#{Twitter.api_version}/users/show/#{id}.json", :query => query)
+    def user(id_or_username, query={})
+      if id_or_username.is_a?(Integer)
+        query.merge!({:user_id => id_or_username})
+      elsif id_or_username.is_a?(String)
+        query.merge!({:screen_name => id_or_username})
+      end
+      perform_get("/#{Twitter.api_version}/users/show.json", :query => query)
     end
 
     def users(*ids_or_usernames)

--- a/test/twitter/base_test.rb
+++ b/test/twitter/base_test.rb
@@ -166,9 +166,15 @@ class BaseTest < Test::Unit::TestCase
         assert !@twitter.friendship_show(:source_screen_name => "dcrec1", :target_screen_name => "pengwynn").relationship.target.followed_by
       end
 
-      should "be able to lookup a user" do
-        stub_get("/1/users/show/4243.json", "user.json")
+      should "be able to lookup a user by id" do
+        stub_get("/1/users/show.json?user_id=4243", "user.json")
         user = @twitter.user(4243)
+        assert_equal 'jnunemaker', user.screen_name
+      end
+
+      should "be able to lookup a user by screen_name" do
+        stub_get("/1/users/show.json?screen_name=jnunemaker", "user.json")
+        user = @twitter.user('jnunemaker')
         assert_equal 'jnunemaker', user.screen_name
       end
 


### PR DESCRIPTION
The libraries Twitter::Base#user method calls the twitter API show method but doesn't conform to the API docs. It should be able to take a users id or screen name. Pull request for issue: http://github.com/jnunemaker/twitter/issues/issue/63
