### PR TITLE
Allow user to catch value of "Retry-After" http header from Search API

### DIFF
--- a/lib/faraday/raise_http_4xx.rb
+++ b/lib/faraday/raise_http_4xx.rb
@@ -14,7 +14,7 @@ module Faraday
         when 406
           raise Twitter::NotAcceptable, error_message(response)
         when 420
-          raise Twitter::EnhanceYourCalm, error_message(response)
+          raise Twitter::EnhanceYourCalm.new error_message(response), response[:response_headers]
         end
       end
     end

--- a/lib/twitter.rb
+++ b/lib/twitter.rb
@@ -92,10 +92,24 @@ module Twitter
   class Unauthorized < StandardError; end
   class Forbidden < StandardError; end
   class NotFound < StandardError; end
-  class NotAcceptable < StandardError; end
-  class EnhanceYourCalm < StandardError; end
+  class NotAcceptable < StandardError; end  
   class InternalServerError < StandardError; end
   class BadGateway < StandardError; end
   class ServiceUnavailable < StandardError; end
-
+  
+  class EnhanceYourCalm < StandardError
+    
+    def initialize(message, http_headers)
+      @http_headers = Hash[http_headers]
+      super message
+    end
+    
+    # Returns number of seconds the application should wait before requesting data from the Search API again.
+    def waiting_time
+      header_value = @http_headers["retry-after"] || @http_headers["Retry-After"]
+      header_value.to_i
+    end
+    
+  end 
+    
 end

--- a/test/faraday/raise_errors_test.rb
+++ b/test/faraday/raise_errors_test.rb
@@ -45,10 +45,14 @@ class RaiseErrorsTest < Test::Unit::TestCase
     end
 
     should "raise EnhanceYourCalm when search is rate limited" do
-      stub_get('https://search.twitter.com/search.json?q=from%3Asferik', 'enhance_your_calm.json', 420)
-      assert_raise Twitter::EnhanceYourCalm do
+      stub_get('https://search.twitter.com/search.json?q=from%3Asferik', 'enhance_your_calm.text', 420, nil, true)
+      begin
         @search.from('sferik')
         @search.fetch
+        flunk 'Should have exception at this point'
+      rescue => err
+        assert_instance_of Twitter::EnhanceYourCalm, err
+        assert_operator err.waiting_time, :> , 0
       end
     end
 

--- a/test/fixtures/enhance_your_calm.json
+++ b/test/fixtures/enhance_your_calm.json
@@ -1,1 +1,0 @@
-{"error":"Enhance Your Calm","request":"/search.json?q=from%3Asferik"}

--- a/test/fixtures/enhance_your_calm.text
+++ b/test/fixtures/enhance_your_calm.text
@@ -1,0 +1,11 @@
+HTTP/1.1 420
+Location: https://search.twitter.com
+Content-Type: application/json; charset=UTF-8
+Date: Mon, 18 Oct 2010 10:20:23 GMT
+Expires: Wed, 17 Nov 2010 10:20:23 GMT
+Cache-Control: public, max-age=2592000
+Server: gws
+Content-Length: 219
+X-XSS-Protection: 1; mode=block
+Retry-After: 100
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,8 +23,9 @@ def twitter_url(url)
   url =~ /^http/ ? url : "https://api.twitter.com#{url}"
 end
 
-def stub_get(url, filename, status=nil, location=nil)
-  options = {:body => fixture_file(filename)}
+def stub_get(url, filename, status=nil, location=nil, content_as_full_response = false)
+  response_content = content_as_full_response ? 'response' : 'body'
+  options = { response_content.to_sym => fixture_file(filename) }  
   options.merge!({:status => status}) unless status.nil?
   options.merge!({:location => location}) unless location.nil?
   FakeWeb.register_uri(:get, twitter_url(url), options)


### PR DESCRIPTION
In "Search API Rate Limiting" from http://dev.twitter.com/pages/rate-limiting, it mentions the application could use Retry-After header to know the appropriate time for performing the next request to Search API again. In this commit I add a method to EnhanceYourCalm class to allow user to catch that header
