### PR TITLE
Typo

### DIFF
--- a/lib/twitter/configuration.rb
+++ b/lib/twitter/configuration.rb
@@ -5,7 +5,7 @@ module Twitter
   # Defines constants and methods related to configuration
   module Configuration
     # An array of valid keys in the options hash when configuring a {Twitter::API}
-    VALID_OPTIONS_KEYS = [:consumer_key, :consumer_secret, :oauth_token, :oauth_token_secret, :adapter, :endpoint, :format, :proxy, :search_endpoint, :user_agent, :user_screen_name].freeze
+    VALID_OPTIONS_KEYS = [:consumer_key, :consumer_secret, :oauth_token, :oauth_token_secret, :adapter, :endpoint, :format, :proxy, :search_endpoint, :user_agent, :screen_name].freeze
 
     # An array of valid request/response formats
     #


### PR DESCRIPTION
VALID_OPTIONS_KEYS had a typo, :user_screen_name instead of :screen_name, which was causing reset (in configuration) to fail.
