### PR TITLE
Use 'tude' parameter for attitude queries

### DIFF
--- a/lib/twitter/search.rb
+++ b/lib/twitter/search.rb
@@ -42,6 +42,7 @@ module Twitter
       @cache = nil
       @query = {}
       @query[:q] = []
+      @query[:tude] = []
       self
     end
 
@@ -133,7 +134,7 @@ module Twitter
     # @example Return an array of tweets containing happy emoticons
     #   Twitter::Search.new.positive.fetch
     def positive
-      @query[:q] << ":)"
+      @query[:tude] << ":)"
       self
     end
 
@@ -143,7 +144,7 @@ module Twitter
     # @example Return an array of tweets containing sad emoticons
     #   Twitter::Search.new.negative.fetch
     def negative
-      @query[:q] << ":("
+      @query[:tude] << ":("
       self
     end
 
@@ -153,7 +154,7 @@ module Twitter
     # @example Return an array of tweets containing question marks
     #   Twitter::Search.new.question.fetch
     def question
-      @query[:q] << "?"
+      @query[:tude] << "?"
       self
     end
 

--- a/spec/twitter/search_spec.rb
+++ b/spec/twitter/search_spec.rb
@@ -261,7 +261,7 @@ describe Twitter::Search do
     describe ".positive" do
 
       it "should set the query to include ':)'" do
-        @client.positive.query[:q].should include ':)'
+        @client.positive.query[:tude].should include ':)'
       end
 
     end
@@ -269,7 +269,7 @@ describe Twitter::Search do
     describe ".negative" do
 
       it "should set the query to include ':('" do
-        @client.negative.query[:q].should include ':('
+        @client.negative.query[:tude].should include ':('
       end
 
     end
@@ -277,7 +277,7 @@ describe Twitter::Search do
     describe ".question" do
 
       it "should set the query to include '?'" do
-        @client.question.query[:q].should include '?'
+        @client.question.query[:tude].should include '?'
       end
 
     end


### PR DESCRIPTION
For positive, negative, and question attitude queries, the Twitter search form uses the 'tude' query string parameter.

e.g. (grr! can't figure out how to get these links to show up correctly .. use copy & paste for now)
<a href="http://search.twitter.com/search?tude[]=:)&rpp=15">http://search.twitter.com/search?tude[]=:)&rpp=15</a>
<a href="http://search.twitter.com/search.json?tude[]=:)&rpp=15">http://search.twitter.com/search.json?tude[]=:)&rpp=15</a>

This patch mirrors the behavior in the twitter gem.

In a few queries I ran, it seems like using tude => ":)" returned the use of :D, =) and a few other smiley types while q => ":)" didn't.
