### PR TITLE
Add Enumerable mixin to Twitter::Search

### DIFF
--- a/lib/twitter/search.rb
+++ b/lib/twitter/search.rb
@@ -16,6 +16,8 @@ module Twitter
   #   {Twitter::Client::User#user} to get the correct user id if necessary.
   # @see http://dev.twitter.com/doc/get/search Twitter Search API Documentation
   class Search < API
+    include Enumerable
+
     # @private
     attr_reader :query
 


### PR DESCRIPTION
Twitter::Search already has an #each method.  By trivially mixing in Enumerable, it gains more potentially useful methods for free.

e.g.,
Twitter::Search.new.mentioning("@gem").collect(&:text)
=> ["@danyelleSkinner @gem  @gem?", "Working out @Gem of the hills. And then a late night tennis match with the guys. LOVIN THIS.", "@gem thanks! Keep up the good work btw :-)", ...]
