### PR TITLE
Support for respond_to? in Twitter class

### DIFF
--- a/lib/twitter.rb
+++ b/lib/twitter.rb
@@ -20,4 +20,9 @@ module Twitter
     return super unless client.respond_to?(method)
     client.send(method, *args, &block)
   end
+
+  # Delegate to Twitter::Client
+  def self.respond_to?(method)
+    return client.respond_to?(method) || super
+  end
 end


### PR DESCRIPTION
I was using the gem and found that:

Twitter.respond_to?(:retweet)

returns false.

I've made a minor modification that fixes this in order to support better self-documentation.

Thanks
