### PR TITLE
refactor: places_similar

### DIFF
--- a/lib/twitter/client/geo.rb
+++ b/lib/twitter/client/geo.rb
@@ -44,7 +44,7 @@ module Twitter
       # @example Return an array of places similar to Twitter HQ
       #   Twitter.places_similar(:lat => "37.7821120598956", :long => "-122.400612831116", :name => "Twitter HQ")
       def places_similar(options={})
-        get('geo/similar_places', options)['result']['places']
+        get('geo/similar_places', options)['result']
       end
 
       # Searches for up to 20 places that can be used as a place_id

--- a/spec/twitter/client/geo_spec.rb
+++ b/spec/twitter/client/geo_spec.rb
@@ -46,8 +46,8 @@ describe Twitter::Client do
 
       it "should return similar places" do
         places = @client.places_similar(:lat => "37.7821120598956", :long => "-122.400612831116", :name => "Twitter HQ")
-        places.should be_an Array
-        places.first.name.should == "Bernal Heights"
+        places.should be_an Hash
+        places[:places].first.name.should == "Bernal Heights"
       end
 
     end


### PR DESCRIPTION
places_similar method return all places without the token that is used for create places.

This pull request contains the patch.
