### PR TITLE
small values_at / first bug in error handler

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -29,7 +29,7 @@ module Twitter
     #
     # @see http://dev.twitter.com/pages/rate-limiting
     def retry_after
-      @http_headers.values_at('retry-after', 'Retry-After').first.to_i
+      @http_headers.values_at('retry-after', 'Retry-After').detect {|value| value }.to_i
     end
   end
 


### PR DESCRIPTION
In the previous code, the values_at method returns a list with two values. However, the second value would be discarded even if the first is nil.
