### PR TITLE
Avoid unnecessary inject

### DIFF
--- a/lib/twitter/configuration.rb
+++ b/lib/twitter/configuration.rb
@@ -82,9 +82,7 @@ module Twitter
 
     # Create a hash of options and their values
     def options
-      VALID_OPTIONS_KEYS.inject({}) do |option, key|
-        option.merge!(key => send(key))
-      end
+      Hash[VALID_OPTIONS_KEYS.map {|key| [key, send(key)] }]
     end
 
     # Reset all configuration options to defaults


### PR DESCRIPTION
It is recommended to avoid using inject when each iteration does not depend on a previous calculation. Using inject to populate a hash is more costly than map plus Hash[].
