### PR TITLE
added http response headers access  to all errors and some methods for accessing rate limit headers

### DIFF
--- a/lib/faraday/raise_http_4xx.rb
+++ b/lib/faraday/raise_http_4xx.rb
@@ -8,17 +8,17 @@ module Faraday
       env[:response].on_complete do |response|
         case response[:status].to_i
         when 400
-          raise Twitter::BadRequest, error_message(response)
+          raise Twitter::BadRequest.new(error_message(response), response[:response_headers])
         when 401
-          raise Twitter::Unauthorized, error_message(response)
+          raise Twitter::Unauthorized.new(error_message(response), response[:response_headers])
         when 403
-          raise Twitter::Forbidden, error_message(response)
+          raise Twitter::Forbidden.new(error_message(response), response[:response_headers])
         when 404
-          raise Twitter::NotFound, error_message(response)
+          raise Twitter::NotFound.new(error_message(response), response[:response_headers])
         when 406
-          raise Twitter::NotAcceptable, error_message(response)
+          raise Twitter::NotAcceptable.new(error_message(response), response[:response_headers])
         when 420
-          raise Twitter::EnhanceYourCalm.new error_message(response), response[:response_headers]
+          raise Twitter::EnhanceYourCalm.new(error_message(response), response[:response_headers])
         end
       end
     end

--- a/lib/faraday/raise_http_5xx.rb
+++ b/lib/faraday/raise_http_5xx.rb
@@ -8,11 +8,11 @@ module Faraday
       env[:response].on_complete do |response|
         case response[:status].to_i
         when 500
-          raise Twitter::InternalServerError, error_message(response, "Something is technically wrong.")
+          raise Twitter::InternalServerError.new(error_message(response, "Something is technically wrong."), response[:response_headers])
         when 502
-          raise Twitter::BadGateway, error_message(response, "Twitter is down or being upgraded.")
+          raise Twitter::BadGateway.new(error_message(response, "Twitter is down or being upgraded."), response[:response_headers])
         when 503
-          raise Twitter::ServiceUnavailable, error_message(response, "(__-){ Twitter is over capacity.")
+          raise Twitter::ServiceUnavailable.new(error_message(response, "(__-){ Twitter is over capacity."), response[:response_headers])
         end
       end
     end

--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -1,6 +1,29 @@
 module Twitter
   # Custom error class for rescuing from all Twitter errors
-  class Error < StandardError; end
+  class Error < StandardError
+    attr_reader :http_headers
+
+    def initialize(message, http_headers)
+      @http_headers = Hash[http_headers]
+      super message
+    end
+
+    def ratelimit_reset
+      Time.at(@http_headers.values_at('x-ratelimit-reset', 'X-RateLimit-Reset').detect {|value| value }.to_i)
+    end
+
+    def ratelimit_limit
+      @http_headers.values_at('x-ratelimit-limit', 'X-RateLimit-Limit').detect {|value| value }.to_i
+    end
+
+    def ratelimit_remaining
+      @http_headers.values_at('x-ratelimit-limit', 'X-RateLimit-Limit').detect {|value| value }.to_i
+    end
+
+    def retry_after
+      [(ratelimit_reset - Time.now).ceil, 0].max
+    end
+  end
 
   # Raised when Twitter returns the HTTP status code 400
   class BadRequest < Error; end
@@ -19,12 +42,6 @@ module Twitter
 
   # Raised when Twitter returns the HTTP status code 420
   class EnhanceYourCalm < Error
-    # Creates a new EnhanceYourCalm error
-    def initialize(message, http_headers)
-      @http_headers = Hash[http_headers]
-      super message
-    end
-
     # The number of seconds your application should wait before requesting date from the Search API again
     #
     # @see http://dev.twitter.com/pages/rate-limiting


### PR DESCRIPTION
I've been hacking this in for a long time now so I thought I'd see about getting it merged.  Whenever I have a twitter error I'm always interested in the response http headers.  Usually for information about rate limiting thought sometimes for other reasons.  As twitter headers evolve I think it will be nice to always be able to catch errors and look at the headers for useful information on how to handle the error.

Perhaps it should have been a separate commit, it could be rebased, but I have some methods for handling rate limit headers.  I have a retry_after method that works similarly to the method used by the search 420 error for methods which receive an array of statuses which can come from either search or a user's timeline and I can catch either rate limit error and respond in the same way.
