### PR TITLE
Fix respond_to parameter list

### DIFF
--- a/lib/twitter.rb
+++ b/lib/twitter.rb
@@ -21,7 +21,7 @@ module Twitter
     client.send(method, *args, &block)
   end
 
-  def self.respond_to?(method)
-    client.respond_to?(method) || super
+  def self.respond_to?(method, include_private = false)
+    client.respond_to?(method, include_private) || super(method, include_private)
   end
 end

--- a/spec/twitter_spec.rb
+++ b/spec/twitter_spec.rb
@@ -26,6 +26,12 @@ describe Twitter do
 
   end
 
+  describe '.respond_to?' do
+    it 'takes an optional include private argument' do
+      Twitter.respond_to?(:client, true).should be_true
+    end
+  end
+
   describe ".client" do
     it "should be a Twitter::Client" do
       Twitter.client.should be_a Twitter::Client


### PR DESCRIPTION
`respond_to?` should take two arguments, first the method name and
second whether to include private methods.

http://www.ruby-doc.org/core/classes/Object.html#M001005
