### PR TITLE
Get info about users and x-ratelimit-limit in a single request

### DIFF
--- a/lib/twitter/client/user.rb
+++ b/lib/twitter/client/user.rb
@@ -41,9 +41,13 @@ module Twitter
       #   Twitter.user(7505382, 14100886)    # Same as above
       def users(*args)
         options = args.last.is_a?(Hash) ? args.pop : {}
+
+        options = {:raw => false}.merge(options)
+        raw = options.delete(:raw)
+
         users = args
         merge_users_into_options!(Array(users), options)
-        response = get('users/lookup', options)
+        response = get('users/lookup', options, raw)
         format.to_s.downcase == 'xml' ? response['users'] : response
       end
 


### PR DESCRIPTION
allow asking for the raw response when getting users (like Twitter.users("sferik", 14100886,{:raw=>true}))
btw, comments in lib\twitter\client\user.rb:39-41 should be Twitter.users, not Twitter.user

I did not find a way to get info about an array of users and x-ratelimit-limit on the same request; I did find it get be done with 2 requests (Twitter.users("sferik")+Twitter.rate_limit_status); if there's already a way to do it with a single request, then ignore this.

with the change I did, we can call raw=Twitter.users(ids, {:raw=>true}) and then parse the result (eventually in a gem method)
users = raw.body.blank? ? [] : JSON("{\"users\" : #{raw.body}}")['users']
remaining = raw.env[:response_headers]['x-ratelimit-remaining'].to_i
