### PR TITLE
Issue #164

### DIFF
--- a/lib/faraday/response/raise_http_4xx.rb
+++ b/lib/faraday/response/raise_http_4xx.rb
@@ -33,7 +33,7 @@ module Faraday
       elsif body['error']
         ": #{body['error']}"
       elsif body['errors']
-        first = body['errors'].to_a.first
+        first = Array(body['errors']).first
         if first.kind_of? Hash
           ": #{first['message'].chomp}"
         else


### PR DESCRIPTION
Updated the raise_http_4xx to use Array() instead of .to_a so that it works under 1.8 and 1.9
