### PR TITLE
Documentation fix

### DIFF
--- a/lib/twitter/client/tweets.rb
+++ b/lib/twitter/client/tweets.rb
@@ -85,7 +85,7 @@ module Twitter
       # Returns up to 100 of the first retweets of a given tweet
       #
       # @format :json, :xml
-      # @authenticated false
+      # @authenticated true
       # @rate_limited true
       # @param id [Integer] The numerical ID of the desired status.
       # @param options [Hash] A customizable set of options.


### PR DESCRIPTION
According to http://dev.twitter.com/doc/get/statuses/retweets/:id this method requires authentication. This method throws when used without authentication. 
