### PR TITLE
pass raw options to faraday

### DIFF
--- a/lib/twitter/configuration.rb
+++ b/lib/twitter/configuration.rb
@@ -16,7 +16,8 @@ module Twitter
       :proxy,
       :search_endpoint,
       :user_agent,
-      :media_endpoint].freeze
+      :media_endpoint,
+      :faraday_options].freeze
 
     # The adapter that will be used to connect if none is set
     DEFAULT_ADAPTER = :net_http
@@ -64,6 +65,8 @@ module Twitter
     # This endpoint will be used by default when updating statuses with media
     DEFAULT_MEDIA_ENDPOINT = 'https://upload.twitter.com/'.freeze
 
+    DEFAULT_FARADAY_OPTIONS = {}.freeze
+
     # @private
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -98,6 +101,7 @@ module Twitter
       self.user_agent         = DEFAULT_USER_AGENT
       self.gateway            = DEFAULT_GATEWAY
       self.media_endpoint     = DEFAULT_MEDIA_ENDPOINT
+      self.faraday_options    = DEFAULT_FARADAY_OPTIONS
       self
     end
   end

--- a/lib/twitter/connection.rb
+++ b/lib/twitter/connection.rb
@@ -12,7 +12,7 @@ module Twitter
     private
 
     def connection(options={})
-      Faraday.new(
+      merged_options = faraday_options.merge({
         :headers => {
           'Accept' => "application/#{format}",
           'User-Agent' => user_agent
@@ -20,7 +20,9 @@ module Twitter
         :proxy => proxy,
         :ssl => {:verify => false},
         :url => options.fetch(:endpoint, api_endpoint)
-      ) do |builder|
+      })
+      
+      Faraday.new(merged_options) do |builder|
         builder.use Faraday::Request::Phoenix if options[:phoenix]
         builder.use Faraday::Request::MultipartWithFile
         builder.use Faraday::Request::TwitterOAuth, authentication if authenticated?

--- a/spec/twitter/api_spec.rb
+++ b/spec/twitter/api_spec.rb
@@ -42,6 +42,7 @@ describe Twitter::API do
           :search_endpoint => 'http://google.com/',
           :media_endpoint => 'https://upload.twitter.com/',
           :user_agent => 'Custom User Agent',
+          :faraday_options => {:timeout => 10}
         }
       end
 

--- a/spec/twitter/search_spec.rb
+++ b/spec/twitter/search_spec.rb
@@ -49,6 +49,7 @@ describe Twitter::Search do
           :search_endpoint => 'http://google.com/',
           :media_endpoint => 'https://upload.twitter.com/',
           :user_agent => 'Custom User Agent',
+          :faraday_options => {:timeout => 10}
         }
       end
 


### PR DESCRIPTION
I did this to work around some specific HTTP problem I was having, but it seems like a generally good idea to allow people access to lower-level APIs, just in case there's some Faraday feature they need that isn't in the Twitter gem.

One way to go even further that direction would be to allow the caller to specify their own Faraday middlewares.
