### PR TITLE
Add support for include_entities and with_twitter_user_id to search

### DIFF
--- a/lib/twitter/search.rb
+++ b/lib/twitter/search.rb
@@ -425,7 +425,7 @@ module Twitter
     # entities are not supported by the search api
     #
     # @return [Twitter::Search] self
-    # @example Return an array of tweets containing "twitter", including the entities inthe tweets.
+    # @example Return an array of tweets containing "twitter", including the entities in the tweets.
     #   Twitter::Search.new.containing("twitter").include_entities().fetch
     #
     def include_entities()
@@ -436,8 +436,8 @@ module Twitter
     # Return the "official" user ids in the to_user_id and from_user_id fields
     #
     # @return [Twitter::Search] self
-    # @example Return an array of tweets containing "twitter", including the entities inthe tweets.
-    #   Twitter::Search.new.containing("twitter").include_entities().fetch
+    # @example Return an array of tweets containing "twitter", and populate the to_user_id and from_user_id fields with the "official" user ids - not the search ones.
+    #   Twitter::Search.new.containing("twitter").with_twitter_user_id().fetch
     #
     def with_twitter_user_id()
       @query[:with_twitter_user_id] = true

--- a/spec/twitter/search_spec.rb
+++ b/spec/twitter/search_spec.rb
@@ -317,6 +317,23 @@ describe Twitter::Search do
 
     end
 
+    describe ".include_entities" do
+
+      it "should set the query to include entities" do
+        @client.include_entities().query[:include_entities].should == true
+      end
+
+    end
+
+    describe ".with_twitter_user_id" do
+
+      it "should set the query to return official user ids" do
+        @client.with_twitter_user_id().query[:with_twitter_user_id].should == true
+      end
+
+    end
+
+
     describe ".page" do
 
       it "should set the page number" do
@@ -324,6 +341,9 @@ describe Twitter::Search do
       end
 
     end
+
+
+
 
     describe ".next_page?" do
 


### PR DESCRIPTION
Hi,

I've added support for including entities and getting the "official" twitter user ids in results from the search API's. I think both of these are new to the API:

https://dev.twitter.com/docs/api/1/get/search

Cheers
Peter
