### PR TITLE
Add accessor for expanded_urls from tweet entities

### DIFF
--- a/lib/twitter/status.rb
+++ b/lib/twitter/status.rb
@@ -22,6 +22,12 @@ module Twitter
       super || (other.class == self.class && other.id == self.id)
     end
 
+    def expanded_urls
+      @expanded_urls ||= Array(@attributes['entities']['urls']).map do |url|
+        url['expanded_url']
+      end unless @attributes['entities'].nil?
+    end
+
     def geo
       @geo ||= Twitter::GeoFactory.new(@attributes['geo']) unless @attributes['geo'].nil?
     end

--- a/spec/twitter/status_spec.rb
+++ b/spec/twitter/status_spec.rb
@@ -89,6 +89,19 @@ describe Twitter::Status do
     end
   end
 
+  describe "#expanded_urls" do
+    it "should return the expanded urls" do
+      urls = [{'expanded_url' => 'http://example.com'}]
+      expanded_urls = Twitter::Status.new('entities' => {'urls' => urls}).expanded_urls
+      expanded_urls.should be_an Array
+      expanded_urls.first.should == "http://example.com"
+    end
+    it "should return nil when not set" do
+      expanded_urls = Twitter::Status.new.expanded_urls
+      expanded_urls.should be_nil
+    end
+  end
+
   describe "#user" do
     it "should return a User when user is set" do
       user = Twitter::Status.new('user' => {}).user


### PR DESCRIPTION
Hey there,

The current Twitter::Status class doesn't provide a convenient way to access the 'expanded_urls' field that the Twitter API returns in the tweet's entities. 

These 'expanded_urls' point to, for example, a yfrog URL where a photo has been uploaded, rather than Twitter's shortener link. Unlike the shortened link, these often point directly at media such as from yfrog which a developer (such as myself!) might like to embed with the tweet's text.

Newer tweets (after October 10th, 2011) sometimes include this in 'media' within the entities, but older tweets don't exhibit this behavior.

Thanks!

Sean
