### PR TITLE
Twitter::Status#all_urls method

### DIFF
--- a/lib/twitter/status.rb
+++ b/lib/twitter/status.rb
@@ -22,6 +22,13 @@ module Twitter
       super || (other.class == self.class && other.id == self.id)
     end
 
+    def all_urls
+      @all_urls ||= begin
+        all_urls = [ urls, expanded_urls ].compact.flatten.uniq
+        all_urls.length > 0 ? all_urls : nil
+      end
+    end
+
     def expanded_urls
       @expanded_urls ||= Array(@attrs['entities']['urls']).map do |url|
         url['expanded_url']

--- a/spec/twitter/status_spec.rb
+++ b/spec/twitter/status_spec.rb
@@ -77,7 +77,7 @@ describe Twitter::Status do
     end
   end
 
-  describe "#url" do
+  describe "#urls" do
     it "should return urls" do
       urls = Twitter::Status.new('text' => "This Tweet contains a http://example.com.").urls
       urls.should be_an Array
@@ -99,6 +99,22 @@ describe Twitter::Status do
     it "should return nil when not set" do
       expanded_urls = Twitter::Status.new.expanded_urls
       expanded_urls.should be_nil
+    end
+  end
+
+  describe "#all_urls" do
+    it "should return urls in the text, and in all fields from the entities" do
+      urls = [{'url' => 'http://t.co/example', 'expanded_url' => 'http://example.com'}]
+      status_attributes = { 'text' => "This tweet contains a http://t.co/example.", 'entities' => {'urls' => urls} }
+      all_urls = Twitter::Status.new(status_attributes).all_urls
+      all_urls.should be_an Array
+      all_urls.first.should == "http://t.co/example"
+      all_urls.last.should  == "http://example.com"
+    end
+
+    it "should return nil when not set" do
+      all_urls = Twitter::Status.new.all_urls
+      all_urls.should be_nil
     end
   end
 


### PR DESCRIPTION
Hey there,

So it looks like depending on how old your tweet is (especially before the Oct 11 2011 t.co switch) you'll see very different entities and URLS and such in Twitter's API response.

Here's a tweet's URL entities (id 126406520777867266) and text from a few days ago:

```
"urls": [ 
    { 
        "url": "http://t.co/y0miz6cf", 
        "display_url": "instagr.am/p/Qnszj/", 
        "expanded_url": "http://instagr.am/p/Qnszj/" 
    } 
], 
"text": "The Internet  http://t.co/y0miz6cf" 
```

Whereas here is a tweet from July 25 2009 (id 2843006385):

```
"urls": [ 
    { 
        "url": "http://twitpic.com/bm7ob", 
        "expanded_url": null 
    } 
],
"text": "Computer time!  http://twitpic.com/bm7ob" 
```

What would help me (and perhaps others?) work with these sort of inconsistent responses is a method that returns all the URLs that are associated with the tweet so that one can work with a consistent interface regardless of the age of the tweet.

Thanks!

Sean
