### PR TITLE
Implementation error in Twitter::Status#all_urls

### DIFF
--- a/lib/twitter/status.rb
+++ b/lib/twitter/status.rb
@@ -24,7 +24,7 @@ module Twitter
 
     def all_urls
       @all_urls ||= begin
-        all_urls = [ urls, expanded_urls ].compact.flatten.uniq
+        all_urls = [ urls, expanded_urls ].flatten.compact.uniq
         all_urls.length > 0 ? all_urls : nil
       end
     end

--- a/spec/twitter/status_spec.rb
+++ b/spec/twitter/status_spec.rb
@@ -33,6 +33,13 @@ describe Twitter::Status do
       all_urls = Twitter::Status.new.all_urls
       all_urls.should be_nil
     end
+    it "should not include nil" do
+      urls = [{'url' => 'http://t.co/example', 'expanded_url' => nil}]
+      status_attributes = { 'text' => "This tweet contains a http://t.co/example.", 'entities' => {'urls' => urls} }
+      all_urls = Twitter::Status.new(status_attributes).all_urls
+      all_urls.should be_an Array
+      all_urls.should == ["http://t.co/example"]
+    end
   end
 
   describe "#expanded_urls" do


### PR DESCRIPTION
Yikes. Flubbed the order of 'compact' and 'flatten' in my implementation.

Was getting things like 

```
['http://example.com/', nil]
```

Corrected it to return

```
['http://example.com/']
```

Wrote a test that fails, might be too defensive, your choice if you think it's worth maintaining the test.

Sorry about that :<
