### PR TITLE
Add a reader for retweeted_status

### DIFF
--- a/lib/twitter/status.rb
+++ b/lib/twitter/status.rb
@@ -59,5 +59,12 @@ module Twitter
       @user ||= Twitter::User.new(@attrs.dup['user'].merge('status' => @attrs.except('user'))) unless @attrs['user'].nil?
     end
 
+    # If this status is itself a retweet, the original tweet is available here.
+    #
+    # @return [Twitter::Status]
+    def retweeted_status
+      @retweeted_status ||= self.class.new(@attrs['retweeted_status']) unless @attrs['retweeted_status'].nil?
+    end
+
   end
 end

--- a/spec/twitter/status_spec.rb
+++ b/spec/twitter/status_spec.rb
@@ -105,4 +105,21 @@ describe Twitter::Status do
     end
   end
 
+  describe "#retweeted_status" do
+    before do
+      @a_retweeted_status = Twitter::Status.new('retweeted_status' => {'text' => 'BOOSH'})
+    end
+    it "should return a Status when retweeted_status is set" do
+      @a_retweeted_status.retweeted_status.should be_a Twitter::Status
+    end
+    it "should return nil when a retweeted_status is NOT set" do
+      status = Twitter::Status.new
+      status.retweeted_status.should be_nil
+    end
+    it "should have text when retweeted_status is set" do
+      status = Twitter::Status.new('retweeted_status' => {'text' => 'BOOSH'})
+      status.retweeted_status.text.should == 'BOOSH'
+    end
+  end
+
 end


### PR DESCRIPTION
The Twitter::Status class needs a reader to access the retweeted_status when the status is itself
a retweet. The retweeted_status should be an instance of Twitter::Status.
