### PR TITLE
Fix typo in documentation

### DIFF
--- a/lib/twitter/list.rb
+++ b/lib/twitter/list.rb
@@ -7,7 +7,7 @@ module Twitter
       :mode, :name, :slug, :subscriber_count, :uri
     alias :following? :following
 
-    # @param other [Twiter::List]
+    # @param other [Twitter::List]
     # @return [Boolean]
     def ==(other)
       super || (other.class == self.class && other.id == self.id)


### PR DESCRIPTION
"Twiter" (with one t) should be "Twitter," with two t's. Found while reviewing documentation at http://rubydoc.info/gems/twitter/2.0.2/Twitter/List
