### PR TITLE
add new search result fields

### DIFF
--- a/lib/twitter/status.rb
+++ b/lib/twitter/status.rb
@@ -12,10 +12,10 @@ require 'twitter/user'
 module Twitter
   class Status < Twitter::Base
     include Twitter::Creatable
-    lazy_attr_reader :favorited, :from_user, :from_user_id, :id,
+    lazy_attr_reader :favorited, :from_user, :from_user_id, :from_user_name, :id,
       :in_reply_to_screen_name, :in_reply_to_attrs_id, :in_reply_to_status_id,
       :in_reply_to_user_id, :iso_language_code, :profile_image_url,
-      :retweet_count, :retweeted, :source, :text, :to_user, :to_user_id,
+      :retweet_count, :retweeted, :source, :text, :to_user, :to_user_id, :to_user_name, 
       :truncated
     alias :favorited? :favorited
     alias :retweeted? :retweeted


### PR DESCRIPTION
Twitter added from_user_name and to_user_name in search results in November, so Twitter::Status should create methods for them

From https://dev.twitter.com/docs/api/1/get/search:
As of November 15th, 2011, the Search API returns a from_user_name field with the display name for the owner of a Tweet, and, if the Tweet is a reply, a to_user_name field with the display name for the user being replied to.
