### PR TITLE
Adding action for list_member_added

### DIFF
--- a/lib/twitter/action_factory.rb
+++ b/lib/twitter/action_factory.rb
@@ -1,8 +1,11 @@
 require 'twitter/favorite'
 require 'twitter/follow'
+require 'twitter/list_member_added'
 require 'twitter/mention'
 require 'twitter/reply'
 require 'twitter/retweet'
+
+require 'active_support/core_ext/string/inflections'
 
 module Twitter
   class ActionFactory
@@ -11,11 +14,11 @@ module Twitter
     #
     # @param attrs [Hash]
     # @raise [ArgumentError] Error raised when supplied argument is missing an 'action' key.
-    # @return [Twitter::Favorite, Twitter::Follow, Twitter::Mention, Twitter::Reply, Twitter::Retweet]
+    # @return [Twitter::Favorite, Twitter::Follow, Twitter::ListMemberAdded, Twitter::Mention, Twitter::Reply, Twitter::Retweet]
     def self.new(action={})
       type = action.delete('action')
       if type
-        Twitter.const_get(type.capitalize.to_sym).new(action)
+        Twitter.const_get(type.camelize.to_sym).new(action)
       else
         raise ArgumentError, "argument must have an 'action' key"
       end

--- a/lib/twitter/list_member_added.rb
+++ b/lib/twitter/list_member_added.rb
@@ -1,0 +1,36 @@
+require 'twitter/action'
+require 'twitter/list'
+require 'twitter/user'
+
+module Twitter
+  class ListMemberAdded < Twitter::Action
+    lazy_attr_reader :target_objects
+
+    # A collection of users who added to the list
+    #
+    # @return [Array<Twitter::User>]
+    def sources
+      @sources = Array(@attrs['sources']).map do |user|
+        Twitter::User.new(user)
+      end
+    end
+
+    # A collection of lists that were added to
+    #
+    # @return [Array<Twitter::List>]
+    def target_objects
+      @target_objects = Array(@attrs['target_objects']).map do |list|
+        Twitter::List.new(list)
+      end
+    end
+
+    # A collection of users who were added to the list
+    #
+    # @return [Array<Twitter::User>]
+    def targets
+      @targets = Array(@attrs['targets']).map do |user|
+        Twitter::User.new(user)
+      end
+    end
+  end
+end

--- a/spec/twitter/action_factory_spec.rb
+++ b/spec/twitter/action_factory_spec.rb
@@ -11,6 +11,10 @@ describe Twitter::ActionFactory do
       action = Twitter::ActionFactory.new('action' => 'follow')
       action.should be_a Twitter::Follow
     end
+    it "should generate a ListMemberAdded" do
+      action = Twitter::ActionFactory.new('action' => 'list_member_added')
+      action.should be_a Twitter::ListMemberAdded
+    end
     it "should generate a Mention" do
       action = Twitter::ActionFactory.new('action' => 'mention')
       action.should be_a Twitter::Mention


### PR DESCRIPTION
Twitter activity has an action called "list_member_added" that is not implemented in this library. When this action comes up, it will throw an exception in action_factory.rb when it tries to create the constant "List_member_added".

I'm adding this action to prevent this failure.
