### PR TITLE
Gateway configuration example using the Apigee vendor as an example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,8 @@ Get your rate limit status
 [justinbieber]: https://twitter.com/justinbieber
 
 ## <a name="proxy"></a>Configuration for API Proxy Services
-Use of API proxy services, like [Apigee](http://apigee.com), can be used to
-attain higher rate limits to the Twitter API.
 
-    Twitter.gateway = YOUR_GATEWAY_HOSTNAME # e.g 'twitter.apigee.com'
+    Twitter.gateway = YOUR_GATEWAY_HOSTNAME # e.g 'gateway.example.com'
 
 ## <a name="contributing"></a>Contributing
 In the spirit of [free software][free-sw], **everyone** is encouraged to help improve

--- a/spec/twitter/client_spec.rb
+++ b/spec/twitter/client_spec.rb
@@ -36,7 +36,7 @@ describe Twitter::Client do
           :oauth_token_secret => 'OS',
           :adapter => :typhoeus,
           :endpoint => 'http://tumblr.com/',
-          :gateway => 'apigee-1111.apigee.com',
+          :gateway => 'gateway.example.com',
           :proxy => 'http://erik:sekret@proxy.example.com:8080',
           :search_endpoint => 'http://google.com/',
           :media_endpoint => 'https://upload.twitter.com/',


### PR DESCRIPTION
I think so because I inquired with Apigee and learned the following:

Increased rate limits for consumers of the Twitter API via Apigee were
previously offered with the Apigee FREEMIUM service. This FREE traffic
is now being routed to a different set of Twitter APIs that do not allow
that increase.

As a side note, It is not part and never has been available with the
Apigee Enterprise product.
