### PR TITLE
Workaround for malformed search API result

### DIFF
--- a/lib/twitter/client/search.rb
+++ b/lib/twitter/client/search.rb
@@ -62,8 +62,12 @@ module Twitter
       # @example Returns tweets related to twitter
       #   Twitter.search('twitter')
       def search(q, options={})
-        get("/search.json", options.merge(:q => q), :endpoint => search_endpoint)['results'].map do |status|
-          Twitter::Status.new(status)
+        if results = get("/search.json", options.merge(:q => q), :endpoint => search_endpoint)['results']
+          results.map do |status|
+            Twitter::Status.new(status)
+          end
+        else
+          []
         end
       end
 

--- a/spec/fixtures/search_malformed.json
+++ b/spec/fixtures/search_malformed.json
@@ -1,0 +1,1 @@
+{"max_id":28857935752,"since_id":0,"refresh_url":"?since_id=28857935752&q=twitter","next_page":"?page=2&max_id=28857935752&q=twitter","results_per_page":15,"page":1,"completed_in":0.017349,"since_id_str":"0","max_id_str":"28857935752","query":"twitter"}

--- a/spec/twitter/client/search_spec.rb
+++ b/spec/twitter/client/search_spec.rb
@@ -66,6 +66,20 @@ describe Twitter::Client do
       search.first.should be_a Twitter::Status
       search.first.text.should == "@KaiserKuo from not too far away your new twitter icon looks like Vader."
     end
+
+    context "when search API responds a malformed result" do
+      before do
+        stub_get("/search.json", Twitter.search_endpoint).
+          with(:query => {:q => "twitter"}).
+          to_return(:body => fixture("/search_malformed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+      end
+
+      it "should not fail and return blank Array" do
+        search = @client.search('twitter')
+        search.should be_an Array
+        search.should have(0).items
+      end
+    end
   end
 
   describe ".phoenix_search" do


### PR DESCRIPTION
Sometimes Twitter Search API returns JSON without `results` section.
This ends with the following error.

undefined method `map' for nil:NilClass (NoMethodError)
/app/vendor/bundle/ruby/1.9.1/gems/twitter-2.2.5/lib/twitter/client/search.rb:68:in`search'

With this patch, Twitter::Client::Search checks  content of `results`, and if
it is nil, return an empty array silently.
