### PR TITLE
keep only one Faraday::Connection regardless of endpoint

### DIFF
--- a/lib/twitter/connection.rb
+++ b/lib/twitter/connection.rb
@@ -13,10 +13,9 @@ module Twitter
 
     # Returns a Faraday::Connection object
     #
-    # @param options [Hash] A hash of options
     # @return [Faraday::Connection]
-    def connection(options={})
-      url = options.fetch(:endpoint, endpoint)
+    def connection
+      return @connection if defined? @connection
       default_options = {
         :headers => {
           :accept => 'application/json',
@@ -24,10 +23,9 @@ module Twitter
         },
         :proxy => proxy,
         :ssl => {:verify => false},
-        :url => url,
+        :url => endpoint
       }
-      @connections ||= {}
-      @connections[url] ||= Faraday.new(default_options.deep_merge(connection_options)) do |builder|
+      @connection = Faraday.new(default_options.deep_merge(connection_options)) do |builder|
         builder.use Twitter::Request::MultipartWithFile
         builder.use Twitter::Request::TwitterOAuth, credentials if credentials?
         builder.use Faraday::Request::Multipart

--- a/spec/twitter/connection_spec.rb
+++ b/spec/twitter/connection_spec.rb
@@ -8,27 +8,13 @@ describe Twitter::Connection do
   end
 
   describe "#connection" do
-    let(:endpoint){ URI.parse("https://api.tweeter.com") }
-
-    it "returns a Faraday connection" do
-      subject.connection.should be_a(Faraday::Connection)
+    it "looks like Faraday connection" do
+      subject.connection.should respond_to(:run_request)
     end
 
     it "memoizes the connection" do
       c1, c2 = subject.connection, subject.connection
       c1.object_id.should == c2.object_id
-    end
-
-    it "optionally sets a custom endpoint" do
-      connection = subject.connection(:endpoint => endpoint)
-      connection.url_prefix.should == endpoint
-    end
-
-    it "memoizes connections, respecting different options" do
-      c1, c2 = subject.connection(:endpoint => endpoint), subject.connection
-      c1.object_id.should_not == c2.object_id
-      c3 = subject.connection(:endpoint => endpoint)
-      c3.object_id.should == c1.object_id
     end
   end
 end


### PR DESCRIPTION
Discussed in #226; references #265.

Special endpoints (such as search, upload) are handled per-request.
