### PR TITLE
define the middleware as a Faraday::Builder

### DIFF
--- a/lib/twitter/config.rb
+++ b/lib/twitter/config.rb
@@ -31,7 +31,7 @@ module Twitter
     DEFAULT_MEDIA_ENDPOINT = 'https://upload.twitter.com'
 
     # The middleware stack if none is set
-    DEFAULT_MIDDLEWARE = Proc.new do |builder|
+    DEFAULT_MIDDLEWARE = Faraday::Builder.new(&Proc.new { |builder|
       builder.use Twitter::Request::MultipartWithFile
       builder.use Faraday::Request::Multipart
       builder.use Faraday::Request::UrlEncoded
@@ -39,7 +39,7 @@ module Twitter
       builder.use Twitter::Response::ParseJson
       builder.use Twitter::Response::RaiseServerError
       builder.adapter Faraday.default_adapter
-    end
+    })
 
     # The oauth token if none is set
     DEFAULT_OAUTH_TOKEN = ENV['TWITTER_OAUTH_TOKEN']

--- a/lib/twitter/requestable.rb
+++ b/lib/twitter/requestable.rb
@@ -41,7 +41,7 @@ module Twitter
 
       options = default_options.deep_merge(connection_options)
 
-      @connection = Faraday.new(endpoint, options, &middleware)
+      @connection = Faraday.new(endpoint, options.merge(:builder => middleware))
     end
 
     # Perform an HTTP request

--- a/spec/twitter_spec.rb
+++ b/spec/twitter_spec.rb
@@ -64,6 +64,12 @@ describe Twitter do
     end
   end
 
+  describe '.middleware' do
+    it "should return a Faraday::Builder" do
+      Twitter.middleware.should be_kind_of(Faraday::Builder)
+    end
+  end
+
   describe ".configure" do
     Twitter::Config::VALID_OPTIONS_KEYS.each do |key|
       it "should set the #{key}" do


### PR DESCRIPTION
Stemming from the discussion in b1c4dab39732cc73f93c9e89ebde5089e210a46b the middleware is now a `Faraday::Builder` instance.  I added a test for the existence of the Builder/stack but stopped short of testing the middleware itself as that is already covered by faraday's tests.

In the process of working on this, I noticed that the tests that use the `media_endpoint` are now failing.  It appears to have something to do with the `Requestable#connection`, I don't see how an alternate endpoint can be defined.  Still investigating.
