### PR TITLE
Assign the Faraday::Connection#url_prefix to ensure correct endpoint is used

### DIFF
--- a/lib/twitter/requestable.rb
+++ b/lib/twitter/requestable.rb
@@ -59,6 +59,7 @@ module Twitter
         headers['Authorization'] = header.to_s
       end
 
+      connection.url_prefix = options[:endpoint] || endpoint
       response = connection.run_request(method.to_sym, path, nil, headers) do |request|
         request.options[:raw] = true if options[:raw]
         unless params.empty?


### PR DESCRIPTION
This is kind of ugly, but resolves the issue mentioned in #269 regarding the failing tests for the `media_endpoint`
