### PR TITLE
use a consistent expectation style in tests

### DIFF
--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -23,7 +23,7 @@ describe Faraday::Response do
             to_return(:status => status)
         end
 
-        it "should raise #{exception.name} error" do
+        it "raises #{exception.name}" do
           lambda do
             @client.user_timeline('sferik')
           end.should raise_error(exception)
@@ -39,7 +39,7 @@ describe Faraday::Response do
               to_return(:status => status, :body => body_message)
           end
 
-          it "should raise #{exception.name} error" do
+          it "raises #{exception.name}" do
             lambda do
               @client.user_timeline('sferik')
             end.should raise_error(exception)
@@ -55,7 +55,7 @@ describe Faraday::Response do
         with(:query => {:screen_name => "not_on_twitter"}).
         to_return(:status => 404, :body => fixture('no_user_matches.json'))
     end
-    it "should raise Twitter::Error::NotFound" do
+    it "raises Twitter::Error::NotFound" do
       lambda do
         @client.users('not_on_twitter')
       end.should raise_error(Twitter::Error::NotFound)

--- a/spec/twitter/action_factory_spec.rb
+++ b/spec/twitter/action_factory_spec.rb
@@ -3,31 +3,31 @@ require 'helper'
 describe Twitter::ActionFactory do
 
   describe ".new" do
-    it "should generate a Favorite" do
+    it "generates a Favorite" do
       action = Twitter::ActionFactory.new('action' => 'favorite')
       action.should be_a Twitter::Favorite
     end
-    it "should generate a Follow" do
+    it "generates a Follow" do
       action = Twitter::ActionFactory.new('action' => 'follow')
       action.should be_a Twitter::Follow
     end
-    it "should generate a ListMemberAdded" do
+    it "generates a ListMemberAdded" do
       action = Twitter::ActionFactory.new('action' => 'list_member_added')
       action.should be_a Twitter::ListMemberAdded
     end
-    it "should generate a Mention" do
+    it "generates a Mention" do
       action = Twitter::ActionFactory.new('action' => 'mention')
       action.should be_a Twitter::Mention
     end
-    it "should generate a Reply" do
+    it "generates a Reply" do
       action = Twitter::ActionFactory.new('action' => 'reply')
       action.should be_a Twitter::Reply
     end
-    it "should generate a Retweet" do
+    it "generates a Retweet" do
       action = Twitter::ActionFactory.new('action' => 'retweet')
       action.should be_a Twitter::Retweet
     end
-    it "should raise an ArgumentError when action is not specified" do
+    it "raises an ArgumentError when action is not specified" do
       lambda do
         Twitter::ActionFactory.new({})
       end.should raise_error(ArgumentError, "argument must have an 'action' key")

--- a/spec/twitter/action_spec.rb
+++ b/spec/twitter/action_spec.rb
@@ -3,11 +3,11 @@ require 'helper'
 describe Twitter::Action do
 
   describe "#created_at" do
-    it "should return a Time when created_at is set" do
+    it "returns a Time when created_at is set" do
       user = Twitter::User.new('created_at' => "Mon Jul 16 12:59:01 +0000 2007")
       user.created_at.should be_a Time
     end
-    it "should return nil when created_at is not set" do
+    it "returns nil when created_at is not set" do
       user = Twitter::User.new
       user.created_at.should be_nil
     end

--- a/spec/twitter/base_spec.rb
+++ b/spec/twitter/base_spec.rb
@@ -7,27 +7,27 @@ describe Twitter::Base do
   end
 
   describe "#[]" do
-    it "should be able to call methods using [] with symbol" do
+    it "calls methods using [] with symbol" do
       @base[:object_id].should be_an Integer
     end
-    it "should be able to call methods using [] with string" do
+    it "calls methods using [] with string" do
       @base['object_id'].should be_an Integer
     end
-    it "should return nil for missing method" do
+    it "returns nil for missing method" do
       @base[:foo].should be_nil
       @base['foo'].should be_nil
     end
   end
 
   describe "#to_hash" do
-    it "should return a hash" do
+    it "returns a hash" do
       @base.to_hash.should be_a Hash
       @base.to_hash['id'].should == 1
     end
   end
 
   describe "identical objects" do
-    it "should have the same object_id" do
+    it "have the same object_id" do
       @base.object_id.should == Twitter::Base.get('id' => 1).object_id
     end
   end

--- a/spec/twitter/client/accounts_spec.rb
+++ b/spec/twitter/client/accounts_spec.rb
@@ -11,12 +11,12 @@ describe Twitter::Client do
       stub_get("/1/account/rate_limit_status.json").
         to_return(:body => fixture("rate_limit_status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.rate_limit_status
       a_get("/1/account/rate_limit_status.json").
         should have_been_made
     end
-    it "should return the remaining number of API requests available to the requesting user before the API limit is reached" do
+    it "returns the remaining number of API requests available to the requesting user before the API limit is reached" do
       rate_limit_status = @client.rate_limit_status
       rate_limit_status.should be_a Twitter::RateLimitStatus
       rate_limit_status.remaining_hits.should == 19993
@@ -28,12 +28,12 @@ describe Twitter::Client do
       stub_get("/1/account/verify_credentials.json").
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.verify_credentials
       a_get("/1/account/verify_credentials.json").
         should have_been_made
     end
-    it "should return the requesting user" do
+    it "returns the requesting user" do
       user = @client.verify_credentials
       user.should be_a Twitter::User
       user.name.should == "Erik Michaels-Ober"
@@ -45,12 +45,12 @@ describe Twitter::Client do
       stub_post("/1/account/end_session.json").
         to_return(:body => fixture("end_session.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.end_session
       a_post("/1/account/end_session.json").
         should have_been_made
     end
-    it "should return a null cookie" do
+    it "returns a null cookie" do
       end_session = @client.end_session
       end_session['error'].should == "Logged out."
     end
@@ -62,13 +62,13 @@ describe Twitter::Client do
         with(:body => {:device => "sms"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.update_delivery_device("sms")
       a_post("/1/account/update_delivery_device.json").
         with(:body => {:device => "sms"}).
         should have_been_made
     end
-    it "should return a user" do
+    it "returns a user" do
       user = @client.update_delivery_device("sms")
       user.should be_a Twitter::User
       user.name.should == "Erik Michaels-Ober"
@@ -81,13 +81,13 @@ describe Twitter::Client do
         with(:body => {:url => "http://github.com/sferik/"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.update_profile(:url => "http://github.com/sferik/")
       a_post("/1/account/update_profile.json").
         with(:body => {:url => "http://github.com/sferik/"}).
         should have_been_made
     end
-    it "should return a user" do
+    it "returns a user" do
       user = @client.update_profile(:url => "http://github.com/sferik/")
       user.should be_a Twitter::User
       user.name.should == "Erik Michaels-Ober"
@@ -99,12 +99,12 @@ describe Twitter::Client do
       stub_post("/1/account/update_profile_background_image.json").
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.update_profile_background_image(fixture("we_concept_bg2.png"))
       a_post("/1/account/update_profile_background_image.json").
         should have_been_made
     end
-    it "should return a user" do
+    it "returns a user" do
       user = @client.update_profile_background_image(fixture("we_concept_bg2.png"))
       user.should be_a Twitter::User
       user.name.should == "Erik Michaels-Ober"
@@ -117,13 +117,13 @@ describe Twitter::Client do
         with(:body => {:profile_background_color => "000000"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.update_profile_colors(:profile_background_color => "000000")
       a_post("/1/account/update_profile_colors.json").
         with(:body => {:profile_background_color => "000000"}).
         should have_been_made
     end
-    it "should return a user" do
+    it "returns a user" do
       user = @client.update_profile_colors(:profile_background_color => "000000")
       user.should be_a Twitter::User
       user.name.should == "Erik Michaels-Ober"
@@ -135,12 +135,12 @@ describe Twitter::Client do
       stub_post("/1/account/update_profile_image.json").
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.update_profile_image(fixture("me.jpeg"))
       a_post("/1/account/update_profile_image.json").
         should have_been_made
     end
-    it "should return a user" do
+    it "returns a user" do
       user = @client.update_profile_image(fixture("me.jpeg"))
       user.should be_a Twitter::User
       user.name.should == "Erik Michaels-Ober"
@@ -155,23 +155,23 @@ describe Twitter::Client do
         with(:body => {:trend_location_woeid => "23424803"}).
         to_return(:body => fixture("settings.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource on GET" do
+    it "requests the correct resource on GET" do
       @client.settings
       a_get("/1/account/settings.json").
         should have_been_made
     end
-    it "should return settings" do
+    it "returns settings" do
       settings = @client.settings
       settings.should be_a Twitter::Settings
       settings.language.should == 'en'
     end
-    it "should request the correct resource on POST" do
+    it "requests the correct resource on POST" do
       @client.settings(:trend_location_woeid => "23424803")
       a_post("/1/account/settings.json").
         with(:body => {:trend_location_woeid => "23424803"}).
         should have_been_made
     end
-    it "should return settings" do
+    it "returns settings" do
       settings = @client.settings(:trend_location_woeid => "23424803")
       settings.should be_a Twitter::Settings
       settings.language.should == 'en'

--- a/spec/twitter/client/activity_spec.rb
+++ b/spec/twitter/client/activity_spec.rb
@@ -11,12 +11,12 @@ describe Twitter::Client do
       stub_get("/i/activity/about_me.json").
         to_return(:body => fixture("about_me.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.activity_about_me
       a_get("/i/activity/about_me.json").
         should have_been_made
     end
-    it "should return activity about me" do
+    it "returns activity about me" do
       activity_about_me = @client.activity_about_me
       activity_about_me.first.should be_a Twitter::Mention
     end
@@ -27,12 +27,12 @@ describe Twitter::Client do
       stub_get("/i/activity/by_friends.json").
         to_return(:body => fixture("by_friends.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.activity_by_friends
       a_get("/i/activity/by_friends.json").
         should have_been_made
     end
-    it "should return activity by friends" do
+    it "returns activity by friends" do
       activity_by_friends = @client.activity_by_friends
       activity_by_friends.first.should be_a Twitter::Favorite
     end

--- a/spec/twitter/client/block_spec.rb
+++ b/spec/twitter/client/block_spec.rb
@@ -11,12 +11,12 @@ describe Twitter::Client do
       stub_get("/1/blocks/blocking.json").
         to_return(:body => fixture("users.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.blocking
       a_get("/1/blocks/blocking.json").
         should have_been_made
     end
-    it "should return an array of user objects that the authenticating user is blocking" do
+    it "returns an array of user objects that the authenticating user is blocking" do
       users = @client.blocking
       users.should be_an Array
       users.first.should be_a Twitter::User
@@ -29,12 +29,12 @@ describe Twitter::Client do
       stub_get("/1/blocks/blocking/ids.json").
         to_return(:body => fixture("ids.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.blocked_ids
       a_get("/1/blocks/blocking/ids.json").
         should have_been_made
     end
-    it "should return an array of numeric user IDs the authenticating user is blocking" do
+    it "returns an array of numeric user IDs the authenticating user is blocking" do
       ids = @client.blocked_ids
       ids.should be_an Array
       ids.first.should == 47
@@ -50,17 +50,17 @@ describe Twitter::Client do
         with(:query => {:screen_name => "pengwynn"}).
         to_return(:body => fixture("not_found.json"), :status => 404, :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.block?("sferik")
       a_get("/1/blocks/exists.json").
         with(:query => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return true if block exists" do
+    it "returns true if block exists" do
       block = @client.block?("sferik")
       block.should be_true
     end
-    it "should return false if block does not exist" do
+    it "returns false if block does not exist" do
       block = @client.block?("pengwynn")
       block.should be_false
     end
@@ -72,12 +72,12 @@ describe Twitter::Client do
         with(:body => {:screen_name => "sferik"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.block("sferik")
       a_post("/1/blocks/create.json").
         should have_been_made
     end
-    it "should return an array of blocked users" do
+    it "returns an array of blocked users" do
       users = @client.block("sferik")
       users.should be_an Array
       users.first.should be_a Twitter::User
@@ -91,13 +91,13 @@ describe Twitter::Client do
         with(:query => {:screen_name => "sferik"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.unblock("sferik")
       a_delete("/1/blocks/destroy.json").
         with(:query => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return an array of un-blocked users" do
+    it "returns an array of un-blocked users" do
       users = @client.unblock("sferik")
       users.should be_an Array
       users.first.should be_a Twitter::User

--- a/spec/twitter/client/direct_messages_spec.rb
+++ b/spec/twitter/client/direct_messages_spec.rb
@@ -11,12 +11,12 @@ describe Twitter::Client do
       stub_get("/1/direct_messages.json").
         to_return(:body => fixture("direct_messages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.direct_messages_received
       a_get("/1/direct_messages.json").
         should have_been_made
     end
-    it "should return the 20 most recent direct messages sent to the authenticating user" do
+    it "returns the 20 most recent direct messages sent to the authenticating user" do
       direct_messages = @client.direct_messages_received
       direct_messages.should be_an Array
       direct_messages.first.should be_a Twitter::DirectMessage
@@ -29,12 +29,12 @@ describe Twitter::Client do
       stub_get("/1/direct_messages/sent.json").
         to_return(:body => fixture("direct_messages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.direct_messages_sent
       a_get("/1/direct_messages/sent.json").
         should have_been_made
     end
-    it "should return the 20 most recent direct messages sent by the authenticating user" do
+    it "returns the 20 most recent direct messages sent by the authenticating user" do
       direct_messages = @client.direct_messages_sent
       direct_messages.should be_an Array
       direct_messages.first.should be_a Twitter::DirectMessage
@@ -47,12 +47,12 @@ describe Twitter::Client do
       stub_delete("/1/direct_messages/destroy/1825785544.json").
         to_return(:body => fixture("direct_message.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.direct_message_destroy(1825785544)
       a_delete("/1/direct_messages/destroy/1825785544.json").
         should have_been_made
     end
-    it "should return an array of deleted messages" do
+    it "returns an array of deleted messages" do
       direct_messages = @client.direct_message_destroy(1825785544)
       direct_messages.should be_an Array
       direct_messages.first.should be_a Twitter::DirectMessage
@@ -66,13 +66,13 @@ describe Twitter::Client do
         with(:body => {:screen_name => "pengwynn", :text => "Creating a fixture for the Twitter gem"}).
         to_return(:body => fixture("direct_message.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.direct_message_create("pengwynn", "Creating a fixture for the Twitter gem")
       a_post("/1/direct_messages/new.json").
         with(:body => {:screen_name => "pengwynn", :text => "Creating a fixture for the Twitter gem"}).
         should have_been_made
     end
-    it "should return the sent message" do
+    it "returns the sent message" do
       direct_message = @client.direct_message_create("pengwynn", "Creating a fixture for the Twitter gem")
       direct_message.should be_a Twitter::DirectMessage
       direct_message.text.should == "Creating a fixture for the Twitter gem"
@@ -84,12 +84,12 @@ describe Twitter::Client do
       stub_get("/1/direct_messages/show/1825786345.json").
         to_return(:body => fixture("direct_message.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.direct_message(1825786345)
       a_get("/1/direct_messages/show/1825786345.json").
         should have_been_made
     end
-    it "should return the specified direct message" do
+    it "returns the specified direct message" do
       direct_message = @client.direct_message(1825786345)
       direct_message.should be_a Twitter::DirectMessage
       direct_message.sender.name.should == "Erik Michaels-Ober"
@@ -102,12 +102,12 @@ describe Twitter::Client do
         stub_get("/1/direct_messages/show/1825786345.json").
           to_return(:body => fixture("direct_message.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.direct_messages(1825786345)
         a_get("/1/direct_messages/show/1825786345.json").
           should have_been_made
       end
-      it "should return an array of direct messages" do
+      it "returns an array of direct messages" do
         direct_messages = @client.direct_messages(1825786345)
         direct_messages.should be_an Array
         direct_messages.first.should be_a Twitter::DirectMessage
@@ -119,12 +119,12 @@ describe Twitter::Client do
         stub_get("/1/direct_messages.json").
           to_return(:body => fixture("direct_messages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.direct_messages
         a_get("/1/direct_messages.json").
           should have_been_made
       end
-      it "should return the 20 most recent direct messages sent to the authenticating user" do
+      it "returns the 20 most recent direct messages sent to the authenticating user" do
         direct_messages = @client.direct_messages
         direct_messages.should be_an Array
         direct_messages.first.should be_a Twitter::DirectMessage

--- a/spec/twitter/client/favorites_spec.rb
+++ b/spec/twitter/client/favorites_spec.rb
@@ -12,12 +12,12 @@ describe Twitter::Client do
         stub_get("/1/favorites/sferik.json").
           to_return(:body => fixture("favorites.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.favorites("sferik")
         a_get("/1/favorites/sferik.json").
           should have_been_made
       end
-      it "should return the 20 most recent favorite statuses for the authenticating user or user specified by the ID parameter" do
+      it "returns the 20 most recent favorite statuses for the authenticating user or user specified by the ID parameter" do
         favorites = @client.favorites("sferik")
         favorites.should be_an Array
         favorites.first.should be_a Twitter::Status
@@ -29,12 +29,12 @@ describe Twitter::Client do
         stub_get("/1/favorites.json").
           to_return(:body => fixture("favorites.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.favorites
         a_get("/1/favorites.json").
           should have_been_made
       end
-      it "should return the 20 most recent favorite statuses for the authenticating user or user specified by the ID parameter" do
+      it "returns the 20 most recent favorite statuses for the authenticating user or user specified by the ID parameter" do
         favorites = @client.favorites
         favorites.should be_an Array
         favorites.first.should be_a Twitter::Status
@@ -48,12 +48,12 @@ describe Twitter::Client do
       stub_post("/1/favorites/create/25938088801.json").
         to_return(:body => fixture("status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.favorite(25938088801)
       a_post("/1/favorites/create/25938088801.json").
         should have_been_made
     end
-    it "should return an array of favorited statuses" do
+    it "returns an array of favorited statuses" do
       statuses = @client.favorite(25938088801)
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -66,12 +66,12 @@ describe Twitter::Client do
       stub_delete("/1/favorites/destroy/25938088801.json").
         to_return(:body => fixture("status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.unfavorite(25938088801)
       a_delete("/1/favorites/destroy/25938088801.json").
         should have_been_made
     end
-    it "should return an array of un-favorited statuses" do
+    it "returns an array of un-favorited statuses" do
       statuses = @client.unfavorite(25938088801)
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status

--- a/spec/twitter/client/friends_and_followers_spec.rb
+++ b/spec/twitter/client/friends_and_followers_spec.rb
@@ -13,13 +13,13 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1", :screen_name => "sferik"}).
           to_return(:body => fixture("id_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.follower_ids("sferik")
         a_get("/1/followers/ids.json").
           with(:query => {:cursor => "-1", :screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return an array of numeric IDs for every user following the specified user" do
+      it "returns an array of numeric IDs for every user following the specified user" do
         follower_ids = @client.follower_ids("sferik")
         follower_ids.should be_a Twitter::Cursor
         follower_ids.ids.should be_an Array
@@ -32,13 +32,13 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1"}).
           to_return(:body => fixture("id_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.follower_ids
         a_get("/1/followers/ids.json").
           with(:query => {:cursor => "-1"}).
           should have_been_made
       end
-      it "should return an array of numeric IDs for every user following the specified user" do
+      it "returns an array of numeric IDs for every user following the specified user" do
         follower_ids = @client.follower_ids
         follower_ids.should be_a Twitter::Cursor
         follower_ids.ids.should be_an Array
@@ -54,13 +54,13 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1", :screen_name => "sferik"}).
           to_return(:body => fixture("id_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friend_ids("sferik")
         a_get("/1/friends/ids.json").
           with(:query => {:cursor => "-1", :screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return an array of numeric IDs for every user the specified user is following" do
+      it "returns an array of numeric IDs for every user the specified user is following" do
         friend_ids = @client.friend_ids("sferik")
         friend_ids.should be_a Twitter::Cursor
         friend_ids.ids.should be_an Array
@@ -73,13 +73,13 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1"}).
           to_return(:body => fixture("id_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friend_ids
         a_get("/1/friends/ids.json").
           with(:query => {:cursor => "-1"}).
           should have_been_made
       end
-      it "should return an array of numeric IDs for every user the specified user is following" do
+      it "returns an array of numeric IDs for every user the specified user is following" do
         friend_ids = @client.friend_ids
         friend_ids.should be_a Twitter::Cursor
         friend_ids.ids.should be_an Array
@@ -98,17 +98,17 @@ describe Twitter::Client do
           with(:query => {:screen_name_a => "pengwynn", :screen_name_b => "sferik"}).
           to_return(:body => fixture("false.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendship?("sferik", "pengwynn")
         a_get("/1/friendships/exists.json").
           with(:query => {:screen_name_a => "sferik", :screen_name_b => "pengwynn"}).
           should have_been_made
       end
-      it "should return true if user A follows user B" do
+      it "returns true if user A follows user B" do
         friendship = @client.friendship?("sferik", "pengwynn")
         friendship.should be_true
       end
-      it "should return false if user A does not follow user B" do
+      it "returns false if user A does not follow user B" do
         friendship = @client.friendship?("pengwynn", "sferik")
         friendship.should be_false
       end
@@ -119,7 +119,7 @@ describe Twitter::Client do
           with(:query => {:user_id_a => "7505382", :user_id_b => "14100886"}).
           to_return(:body => fixture("true.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendship?(7505382, 14100886)
         a_get("/1/friendships/exists.json").
           with(:query => {:user_id_a => "7505382", :user_id_b => "14100886"}).
@@ -133,7 +133,7 @@ describe Twitter::Client do
             with(:query => {:screen_name_a => "sferik", :screen_name_b => "pengwynn"}).
             to_return(:body => fixture("true.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user1 = Twitter::User.new('screen_name' => 'sferik')
           user2 = Twitter::User.new('screen_name' => 'pengwynn')
           @client.friendship?(user1, user2)
@@ -148,7 +148,7 @@ describe Twitter::Client do
             with(:query => {:user_id_a => "7505382", :user_id_b => "14100886"}).
             to_return(:body => fixture("true.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user1 = Twitter::User.new('id' => '7505382')
           user2 = Twitter::User.new('id' => '14100886')
           @client.friendship?(user1, user2)
@@ -166,13 +166,13 @@ describe Twitter::Client do
         with(:query => {:cursor => "-1"}).
         to_return(:body => fixture("id_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.friendships_incoming
       a_get("/1/friendships/incoming.json").
         with(:query => {:cursor => "-1"}).
         should have_been_made
     end
-    it "should return an array of numeric IDs for every user who has a pending request to follow the authenticating user" do
+    it "returns an array of numeric IDs for every user who has a pending request to follow the authenticating user" do
       friendships_incoming = @client.friendships_incoming
       friendships_incoming.should be_a Twitter::Cursor
       friendships_incoming.ids.should be_an Array
@@ -186,13 +186,13 @@ describe Twitter::Client do
         with(:query => {:cursor => "-1"}).
         to_return(:body => fixture("id_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.friendships_outgoing
       a_get("/1/friendships/outgoing.json").
         with(:query => {:cursor => "-1"}).
         should have_been_made
     end
-    it "should return an array of numeric IDs for every protected user for whom the authenticating user has a pending follow request" do
+    it "returns an array of numeric IDs for every protected user for whom the authenticating user has a pending follow request" do
       friendships_outgoing = @client.friendships_outgoing
       friendships_outgoing.should be_a Twitter::Cursor
       friendships_outgoing.ids.should be_an Array
@@ -207,13 +207,13 @@ describe Twitter::Client do
           with(:query => {:source_screen_name => "sferik", :target_screen_name => "pengwynn"}).
           to_return(:body => fixture("relationship.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendship("sferik", "pengwynn")
         a_get("/1/friendships/show.json").
           with(:query => {:source_screen_name => "sferik", :target_screen_name => "pengwynn"}).
           should have_been_made
       end
-      it "should return detailed information about the relationship between two users" do
+      it "returns detailed information about the relationship between two users" do
         relationship = @client.friendship("sferik", "pengwynn")
         relationship.should be_a Twitter::Relationship
         relationship.source.screen_name.should == "sferik"
@@ -225,7 +225,7 @@ describe Twitter::Client do
           with(:query => {:source_screen_name => "0", :target_screen_name => "311"}).
           to_return(:body => fixture("relationship.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendship("0", "311")
         a_get("/1/friendships/show.json").
           with(:query => {:source_screen_name => "0", :target_screen_name => "311"}).
@@ -238,7 +238,7 @@ describe Twitter::Client do
           with(:query => {:source_id => "7505382", :target_id => "14100886"}).
           to_return(:body => fixture("relationship.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendship(7505382, 14100886)
         a_get("/1/friendships/show.json").
           with(:query => {:source_id => "7505382", :target_id => "14100886"}).
@@ -252,7 +252,7 @@ describe Twitter::Client do
             with(:query => {:source_screen_name => "sferik", :target_screen_name => "pengwynn"}).
             to_return(:body => fixture("relationship.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user1 = Twitter::User.new('screen_name' => 'sferik')
           user2 = Twitter::User.new('screen_name' => 'pengwynn')
           @client.friendship(user1, user2)
@@ -267,7 +267,7 @@ describe Twitter::Client do
             with(:query => {:source_id => "7505382", :target_id => "14100886"}).
             to_return(:body => fixture("relationship.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user1 = Twitter::User.new('id' => '7505382')
           user2 = Twitter::User.new('id' => '14100886')
           @client.friendship(user1, user2)
@@ -292,7 +292,7 @@ describe Twitter::Client do
           with(:body => {:user_id => "7505382", :follow => "true"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.follow("sferik", "pengwynn", :follow => true)
         a_get("/1/friends/ids.json").
           with(:query => {:cursor => "-1"}).
@@ -304,7 +304,7 @@ describe Twitter::Client do
           with(:body => {:user_id => "7505382", :follow => "true"}).
           should have_been_made
       end
-      it "should return an array of befriended users" do
+      it "returns an array of befriended users" do
         users = @client.follow("sferik", "pengwynn", :follow => true)
         users.should be_an Array
         users.first.should be_a Twitter::User
@@ -323,7 +323,7 @@ describe Twitter::Client do
           with(:body => {:user_id => "7505382"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.follow("sferik", "pengwynn", :follow => false)
         a_get("/1/friends/ids.json").
           with(:query => {:cursor => "-1"}).
@@ -335,7 +335,7 @@ describe Twitter::Client do
           with(:body => {:user_id => "7505382"}).
           should have_been_made
       end
-      it "should return an array of befriended users" do
+      it "returns an array of befriended users" do
         users = @client.follow("sferik", "pengwynn", :follow => false)
         users.should be_an Array
         users.first.should be_a Twitter::User
@@ -354,7 +354,7 @@ describe Twitter::Client do
           with(:body => {:user_id => "7505382"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.follow("sferik", "pengwynn")
         a_get("/1/friends/ids.json").
           with(:query => {:cursor => "-1"}).
@@ -366,7 +366,7 @@ describe Twitter::Client do
           with(:body => {:user_id => "7505382"}).
           should have_been_made
       end
-      it "should return an array of befriended users" do
+      it "returns an array of befriended users" do
         users = @client.follow("sferik", "pengwynn")
         users.should be_an Array
         users.first.should be_a Twitter::User
@@ -382,13 +382,13 @@ describe Twitter::Client do
           with(:body => {:screen_name => "sferik", :follow => "true"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.follow!("sferik", :follow => true)
         a_post("/1/friendships/create.json").
           with(:body => {:screen_name => "sferik", :follow => "true"}).
           should have_been_made
       end
-      it "should return an array of befriended users" do
+      it "returns an array of befriended users" do
         users = @client.follow!("sferik", :follow => true)
         users.should be_an Array
         users.first.should be_a Twitter::User
@@ -401,13 +401,13 @@ describe Twitter::Client do
           with(:body => {:screen_name => "sferik"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.follow!("sferik", :follow => false)
         a_post("/1/friendships/create.json").
           with(:body => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return an array of befriended users" do
+      it "returns an array of befriended users" do
         users = @client.follow!("sferik", :follow => false)
         users.should be_an Array
         users.first.should be_a Twitter::User
@@ -420,13 +420,13 @@ describe Twitter::Client do
           with(:body => {:screen_name => "sferik"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.follow!("sferik")
         a_post("/1/friendships/create.json").
           with(:body => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return an array of befriended users" do
+      it "returns an array of befriended users" do
         users = @client.follow!("sferik")
         users.should be_an Array
         users.first.should be_a Twitter::User
@@ -441,13 +441,13 @@ describe Twitter::Client do
         with(:query => {:screen_name => "sferik"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.unfollow("sferik")
       a_delete("/1/friendships/destroy.json").
         with(:query => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return an array of unfollowed users" do
+    it "returns an array of unfollowed users" do
       users = @client.friendship_destroy("sferik")
       users.should be_an Array
       users.first.should be_a Twitter::User
@@ -462,13 +462,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik,pengwynn"}).
           to_return(:body => fixture("friendships.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendships("sferik", "pengwynn")
         a_get("/1/friendships/lookup.json").
           with(:query => {:screen_name => "sferik,pengwynn"}).
           should have_been_made
       end
-      it "should return up to 100 users worth of extended information" do
+      it "returns up to 100 users worth of extended information" do
         friendships = @client.friendships("sferik", "pengwynn")
         friendships.should be_an Array
         friendships.first.should be_a Twitter::User
@@ -482,7 +482,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "0,311"}).
           to_return(:body => fixture("friendships.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendships("0", "311")
         a_get("/1/friendships/lookup.json").
           with(:query => {:screen_name => "0,311"}).
@@ -495,7 +495,7 @@ describe Twitter::Client do
           with(:query => {:user_id => "7505382,14100886"}).
           to_return(:body => fixture("friendships.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendships(7505382, 14100886)
         a_get("/1/friendships/lookup.json").
           with(:query => {:user_id => "7505382,14100886"}).
@@ -508,7 +508,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik", :user_id => "14100886"}).
           to_return(:body => fixture("friendships.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendships("sferik", 14100886)
         a_get("/1/friendships/lookup.json").
           with(:query => {:screen_name => "sferik", :user_id => "14100886"}).
@@ -524,13 +524,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik,pengwynn"}).
           to_return(:body => fixture("friendships.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendships("sferik", "pengwynn")
         a_get("/1/friendships/lookup.json").
           with(:query => {:screen_name => "sferik,pengwynn"}).
           should have_been_made
       end
-      it "should return up to 100 users worth of extended information" do
+      it "returns up to 100 users worth of extended information" do
         friendships = @client.friendships("sferik", "pengwynn")
         friendships.should be_an Array
         friendships.first.should be_a Twitter::User
@@ -544,7 +544,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "0,311"}).
           to_return(:body => fixture("friendships.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendships("0", "311")
         a_get("/1/friendships/lookup.json").
           with(:query => {:screen_name => "0,311"}).
@@ -557,7 +557,7 @@ describe Twitter::Client do
           with(:query => {:user_id => "7505382,14100886"}).
           to_return(:body => fixture("friendships.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendships(7505382, 14100886)
         a_get("/1/friendships/lookup.json").
           with(:query => {:user_id => "7505382,14100886"}).
@@ -570,7 +570,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik", :user_id => "14100886"}).
           to_return(:body => fixture("friendships.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.friendships("sferik", 14100886)
         a_get("/1/friendships/lookup.json").
           with(:query => {:screen_name => "sferik", :user_id => "14100886"}).
@@ -585,13 +585,13 @@ describe Twitter::Client do
         with(:body => {:screen_name => "sferik", :retweets => "true"}).
         to_return(:body => fixture("relationship.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.friendship_update("sferik", :retweets => true)
       a_post("/1/friendships/update.json").
         with(:body => {:screen_name => "sferik", :retweets => "true"}).
         should have_been_made
     end
-    it "should return detailed information about the relationship between two users" do
+    it "returns detailed information about the relationship between two users" do
       relationship = @client.friendship_update("sferik", :retweets => true)
       relationship.should be_a Twitter::Relationship
       relationship.source.screen_name.should == "sferik"
@@ -603,12 +603,12 @@ describe Twitter::Client do
       stub_get("/1/friendships/no_retweet_ids.json").
         to_return(:body => fixture("ids.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.no_retweet_ids
       a_get("/1/friendships/no_retweet_ids.json").
         should have_been_made
     end
-    it "should return detailed information about the relationship between two users" do
+    it "returns detailed information about the relationship between two users" do
       no_retweet_ids = @client.no_retweet_ids
       no_retweet_ids.should be_an Array
       no_retweet_ids.first.should be_an Integer
@@ -622,13 +622,13 @@ describe Twitter::Client do
         with(:body => {:screen_name => "sferik"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.accept("sferik")
       a_post("/1/friendships/accept.json").
         with(:body => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return an array of accepted users" do
+    it "returns an array of accepted users" do
       users = @client.accept("sferik")
       users.should be_an Array
       users.first.should be_a Twitter::User
@@ -642,13 +642,13 @@ describe Twitter::Client do
         with(:body => {:screen_name => "sferik"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.deny("sferik")
       a_post("/1/friendships/deny.json").
         with(:body => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return an array of denied users" do
+    it "returns an array of denied users" do
       users = @client.deny("sferik")
       users.should be_an Array
       users.first.should be_a Twitter::User

--- a/spec/twitter/client/help_spec.rb
+++ b/spec/twitter/client/help_spec.rb
@@ -11,12 +11,12 @@ describe Twitter::Client do
       stub_get("/1/help/configuration.json").
         to_return(:body => fixture("configuration.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.configuration
       a_get("/1/help/configuration.json").
         should have_been_made
     end
-    it "should return Twitter's current configuration" do
+    it "returns Twitter's current configuration" do
       configuration = @client.configuration
       configuration.should be_a Twitter::Configuration
       configuration.characters_reserved_per_media.should == 20
@@ -28,12 +28,12 @@ describe Twitter::Client do
       stub_get("/1/help/languages.json").
         to_return(:body => fixture("languages.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.languages
       a_get("/1/help/languages.json").
         should have_been_made
     end
-    it "should return the list of languages supported by Twitter" do
+    it "returns the list of languages supported by Twitter" do
       languages = @client.languages
       languages.should be_an Array
       languages.first.should be_a Twitter::Language

--- a/spec/twitter/client/legal_spec.rb
+++ b/spec/twitter/client/legal_spec.rb
@@ -11,12 +11,12 @@ describe Twitter::Client do
       stub_get("/1/legal/privacy.json").
         to_return(:body => fixture("privacy.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.privacy
       a_get("/1/legal/privacy.json").
         should have_been_made
     end
-    it "should return Twitter's Privacy Policy" do
+    it "returns Twitter's Privacy Policy" do
       privacy = @client.privacy
       privacy.split.first.should == "Twitter"
     end
@@ -27,12 +27,12 @@ describe Twitter::Client do
       stub_get("/1/legal/tos.json").
         to_return(:body => fixture("tos.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.tos
       a_get("/1/legal/tos.json").
         should have_been_made
     end
-    it "should return Twitter's Terms of Service" do
+    it "returns Twitter's Terms of Service" do
       tos = @client.tos
       tos.split.first.should == "Terms"
     end

--- a/spec/twitter/client/lists_spec.rb
+++ b/spec/twitter/client/lists_spec.rb
@@ -13,13 +13,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("all.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.lists_subscribed_to("sferik")
         a_get("/1/lists/all.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return the lists the specified user subscribes to" do
+      it "returns the lists the specified user subscribes to" do
         lists = @client.lists_subscribed_to("sferik")
         lists.should be_an Array
         lists.first.should be_a Twitter::List
@@ -33,7 +33,7 @@ describe Twitter::Client do
         stub_get("/1/lists/all.json").
           to_return(:body => fixture("all.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.lists_subscribed_to
         a_get("/1/lists/all.json").
           should have_been_made
@@ -48,13 +48,13 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_timeline("sferik", "presidents")
         a_get("/1/lists/statuses.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           should have_been_made
       end
-      it "should return the timeline for members of the specified list" do
+      it "returns the timeline for members of the specified list" do
         statuses = @client.list_timeline("sferik", "presidents")
         statuses.should be_an Array
         statuses.first.should be_a Twitter::Status
@@ -69,7 +69,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_timeline("presidents")
         a_get("/1/lists/statuses.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
@@ -85,13 +85,13 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_remove_member("sferik", "presidents", 813286)
         a_post("/1/lists/members/destroy.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286"}).
           should have_been_made
       end
-      it "should return the list" do
+      it "returns the list" do
         list = @client.list_remove_member("sferik", "presidents", 813286)
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -105,7 +105,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_remove_member("presidents", 813286)
         a_post("/1/lists/members/destroy.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286"}).
@@ -121,13 +121,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => 'pengwynn', :cursor => "-1"}).
           to_return(:body => fixture("lists.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.memberships("pengwynn")
         a_get("/1/lists/memberships.json").
           with(:query => {:screen_name => 'pengwynn', :cursor => "-1"}).
           should have_been_made
       end
-      it "should return the lists the specified user has been added to" do
+      it "returns the lists the specified user has been added to" do
         memberships = @client.memberships("pengwynn")
         memberships.should be_a Twitter::Cursor
         memberships.lists.should be_an Array
@@ -143,7 +143,7 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1"}).
           to_return(:body => fixture("lists.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.memberships
         a_get("/1/lists/memberships.json").
           with(:query => {:cursor => "-1"}).
@@ -159,13 +159,13 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :cursor => "-1"}).
           to_return(:body => fixture("users_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscribers("sferik", "presidents")
         a_get("/1/lists/subscribers.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :cursor => "-1"}).
           should have_been_made
       end
-      it "should return the subscribers of the specified list" do
+      it "returns the subscribers of the specified list" do
         list_subscribers = @client.list_subscribers("sferik", "presidents")
         list_subscribers.should be_a Twitter::Cursor
         list_subscribers.users.should be_an Array
@@ -181,7 +181,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :cursor => "-1"}).
           to_return(:body => fixture("users_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscribers("presidents")
         a_get("/1/lists/subscribers.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :cursor => "-1"}).
@@ -197,13 +197,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => 'pengwynn', :cursor => "-1"}).
           to_return(:body => fixture("lists.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.subscriptions("pengwynn")
         a_get("/1/lists/subscriptions.json").
           with(:query => {:screen_name => 'pengwynn', :cursor => "-1"}).
           should have_been_made
       end
-      it "should return the lists the specified user follows" do
+      it "returns the lists the specified user follows" do
         subscriptions = @client.subscriptions("pengwynn")
         subscriptions.should be_a Twitter::Cursor
         subscriptions.lists.should be_an Array
@@ -219,7 +219,7 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1"}).
           to_return(:body => fixture("lists.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.subscriptions
         a_get("/1/lists/subscriptions.json").
           with(:query => {:cursor => "-1"}).
@@ -235,13 +235,13 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscribe("sferik", "presidents")
         a_post("/1/lists/subscribers/create.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           should have_been_made
       end
-      it "should return the specified list" do
+      it "returns the specified list" do
         list = @client.list_subscribe("sferik", "presidents")
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -255,7 +255,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscribe("presidents")
         a_post("/1/lists/subscribers/create.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
@@ -277,21 +277,21 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '12345678'}).
           to_return(:body => fixture("not_found.json"), :status => 403, :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscriber?("sferik", "presidents", 813286)
         a_get("/1/lists/subscribers/show.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '813286'}).
           should have_been_made
       end
-      it "should return true if the specified user subscribes to the specified list" do
+      it "returns true if the specified user subscribes to the specified list" do
         list_subscriber = @client.list_subscriber?("sferik", "presidents", 813286)
         list_subscriber.should be_true
       end
-      it "should return false if the specified user does not subscribe to the specified list" do
+      it "returns false if the specified user does not subscribe to the specified list" do
         list_subscriber = @client.list_subscriber?("sferik", "presidents", 18755393)
         list_subscriber.should be_false
       end
-      it "should return false if user does not exist" do
+      it "returns false if user does not exist" do
         list_subscriber = @client.list_subscriber?("sferik", "presidents", 12345678)
         list_subscriber.should be_false
       end
@@ -302,7 +302,7 @@ describe Twitter::Client do
           with(:query => {:owner_id => '12345678', :slug => 'presidents', :user_id => '813286'}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscriber?(12345678, "presidents", 813286)
         a_get("/1/lists/subscribers/show.json").
           with(:query => {:owner_id => '12345678', :slug => 'presidents', :user_id => '813286'}).
@@ -315,7 +315,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678', :user_id => '813286'}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscriber?('sferik', 12345678, 813286)
         a_get("/1/lists/subscribers/show.json").
           with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678', :user_id => '813286'}).
@@ -329,7 +329,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '813286'}).
             to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('slug' => 'presidents', 'user' => {'screen_name' => 'sferik'})
           @client.list_subscriber?(list, 813286)
           a_get("/1/lists/subscribers/show.json").
@@ -343,7 +343,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678', :user_id => '813286'}).
             to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('id' => 12345678, 'user' => {'screen_name' => 'sferik'})
           @client.list_subscriber?(list, 813286)
           a_get("/1/lists/subscribers/show.json").
@@ -358,7 +358,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :screen_name => 'erebor'}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscriber?("sferik", "presidents", 'erebor')
         a_get("/1/lists/subscribers/show.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :screen_name => 'erebor'}).
@@ -373,7 +373,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '813286'}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_subscriber?("presidents", 813286)
         a_get("/1/lists/subscribers/show.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '813286'}).
@@ -389,13 +389,13 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_unsubscribe("sferik", "presidents")
         a_post("/1/lists/subscribers/destroy.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           should have_been_made
       end
-      it "should return the specified list" do
+      it "returns the specified list" do
         list = @client.list_unsubscribe("sferik", "presidents")
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -409,7 +409,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_unsubscribe("presidents")
         a_post("/1/lists/subscribers/destroy.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
@@ -425,13 +425,13 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_add_members("sferik", "presidents", [813286, 18755393])
         a_post("/1/lists/members/create_all.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393"}).
           should have_been_made
       end
-      it "should return the list" do
+      it "returns the list" do
         list = @client.list_add_members("sferik", "presidents", [813286, 18755393])
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -443,7 +443,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393", :screen_name => "pengwynn,erebor"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_add_members('sferik', 'presidents', [813286, 'pengwynn', 18755393, 'erebor'])
         a_post("/1/lists/members/create_all.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393", :screen_name => "pengwynn,erebor"}).
@@ -458,7 +458,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_add_members("presidents", [813286, 18755393])
         a_post("/1/lists/members/create_all.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393"}).
@@ -474,13 +474,13 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_remove_members("sferik", "presidents", [813286, 18755393])
         a_post("/1/lists/members/destroy_all.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393"}).
           should have_been_made
       end
-      it "should return the list" do
+      it "returns the list" do
         list = @client.list_remove_members("sferik", "presidents", [813286, 18755393])
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -492,7 +492,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393", :screen_name => "pengwynn,erebor"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_remove_members('sferik', 'presidents', [813286, 'pengwynn', 18755393, 'erebor'])
         a_post("/1/lists/members/destroy_all.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393", :screen_name => "pengwynn,erebor"}).
@@ -507,7 +507,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_remove_members("presidents", [813286, 18755393])
         a_post("/1/lists/members/destroy_all.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286,18755393"}).
@@ -529,21 +529,21 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '12345678'}).
           to_return(:body => fixture("not_found.json"), :status => 403, :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_member?("sferik", "presidents", 813286)
         a_get("/1/lists/members/show.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '813286'}).
           should have_been_made
       end
-      it "should return true if user is a list member" do
+      it "returns true if user is a list member" do
         list_member = @client.list_member?("sferik", "presidents", 813286)
         list_member.should be_true
       end
-      it "should return false if user is not a list member" do
+      it "returns false if user is not a list member" do
         list_member = @client.list_member?("sferik", "presidents", 65493023)
         list_member.should be_false
       end
-      it "should return false if user does not exist" do
+      it "returns false if user does not exist" do
         list_member = @client.list_member?("sferik", "presidents", 12345678)
         list_member.should be_false
       end
@@ -554,7 +554,7 @@ describe Twitter::Client do
           with(:query => {:owner_id => '12345678', :slug => 'presidents', :user_id => '813286'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_member?(12345678, "presidents", 813286)
         a_get("/1/lists/members/show.json").
           with(:query => {:owner_id => '12345678', :slug => 'presidents', :user_id => '813286'}).
@@ -567,7 +567,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678', :user_id => '813286'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_member?('sferik', 12345678, 813286)
         a_get("/1/lists/members/show.json").
           with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678', :user_id => '813286'}).
@@ -581,7 +581,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '813286'}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('slug' => 'presidents', 'user' => {'screen_name' => 'sferik'})
           @client.list_member?(list, 813286)
           a_get("/1/lists/members/show.json").
@@ -595,7 +595,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678', :user_id => '813286'}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('id' => 12345678, 'user' => {'screen_name' => 'sferik'})
           @client.list_member?(list, 813286)
           a_get("/1/lists/members/show.json").
@@ -610,7 +610,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :screen_name => 'erebor'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/.json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_member?("sferik", "presidents", 'erebor')
         a_get("/1/lists/members/show.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :screen_name => 'erebor'}).
@@ -625,7 +625,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '813286'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/.json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_member?("presidents", 813286)
         a_get("/1/lists/members/show.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => '813286'}).
@@ -641,13 +641,13 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :cursor => "-1"}).
           to_return(:body => fixture("users_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_members("sferik", "presidents")
         a_get("/1/lists/members.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :cursor => "-1"}).
           should have_been_made
       end
-      it "should return the members of the specified list" do
+      it "returns the members of the specified list" do
         list_members = @client.list_members("sferik", "presidents")
         list_members.should be_a Twitter::Cursor
         list_members.users.should be_an Array
@@ -663,7 +663,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :cursor => "-1"}).
           to_return(:body => fixture("users_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_members("presidents")
         a_get("/1/lists/members.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents', :cursor => "-1"}).
@@ -679,13 +679,13 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_add_member("sferik", "presidents", 813286)
         a_post("/1/lists/members/create.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286"}).
           should have_been_made
       end
-      it "should return the list" do
+      it "returns the list" do
         list = @client.list_add_member("sferik", "presidents", 813286)
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -699,7 +699,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_add_member("presidents", 813286)
         a_post("/1/lists/members/create.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :user_id => "813286"}).
@@ -715,13 +715,13 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_destroy("sferik", "presidents")
         a_delete("/1/lists/destroy.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           should have_been_made
       end
-      it "should return the deleted list" do
+      it "returns the deleted list" do
         list = @client.list_destroy("sferik", "presidents")
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -735,7 +735,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_destroy("presidents")
         a_delete("/1/lists/destroy.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
@@ -748,7 +748,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_destroy("sferik", 12345678)
         a_delete("/1/lists/destroy.json").
           with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678'}).
@@ -762,7 +762,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('slug' => 'presidents', 'user' => {'screen_name' => 'sferik'})
           @client.list_destroy(list)
           a_delete("/1/lists/destroy.json").
@@ -776,7 +776,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678'}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('id' => '12345678', 'user' => {'screen_name' => 'sferik'})
           @client.list_destroy(list)
           a_delete("/1/lists/destroy.json").
@@ -794,13 +794,13 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => "presidents", :description => "Presidents of the United States of America"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_update("sferik", "presidents", :description => "Presidents of the United States of America")
         a_post("/1/lists/update.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => "presidents", :description => "Presidents of the United States of America"}).
           should have_been_made
       end
-      it "should return the updated list" do
+      it "returns the updated list" do
         list = @client.list_update("sferik", "presidents", :description => "Presidents of the United States of America")
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -814,7 +814,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :description => "Presidents of the United States of America"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_update("presidents", :description => "Presidents of the United States of America")
         a_post("/1/lists/update.json").
           with(:body => {:owner_screen_name => 'sferik', :slug => 'presidents', :description => "Presidents of the United States of America"}).
@@ -827,7 +827,7 @@ describe Twitter::Client do
           with(:body => {:owner_screen_name => 'sferik', :list_id => '12345678', :description => "Presidents of the United States of America"}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list_update("sferik", 12345678, :description => "Presidents of the United States of America")
         a_post("/1/lists/update.json").
           with(:body => {:owner_screen_name => 'sferik', :list_id => '12345678', :description => "Presidents of the United States of America"}).
@@ -841,7 +841,7 @@ describe Twitter::Client do
             with(:body => {:owner_screen_name => 'sferik', :slug => "presidents", :description => "Presidents of the United States of America"}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('slug' => 'presidents', 'user' => {'screen_name' => 'sferik'})
           @client.list_update(list, :description => "Presidents of the United States of America")
           a_post("/1/lists/update.json").
@@ -855,7 +855,7 @@ describe Twitter::Client do
             with(:body => {:owner_screen_name => 'sferik', :list_id => '12345678', :description => "Presidents of the United States of America"}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('id' => '12345678', 'user' => {'screen_name' => 'sferik'})
           @client.list_update(list, :description => "Presidents of the United States of America")
           a_post("/1/lists/update.json").
@@ -872,13 +872,13 @@ describe Twitter::Client do
         with(:body => {:name => "presidents"}).
         to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.list_create("presidents")
       a_post("/1/lists/create.json").
         with(:body => {:name => "presidents"}).
         should have_been_made
     end
-    it "should return the created list" do
+    it "returns the created list" do
       list = @client.list_create("presidents")
       list.should be_a Twitter::List
       list.name.should == "presidents"
@@ -892,13 +892,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => 'sferik', :cursor => "-1"}).
           to_return(:body => fixture("lists.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.lists("sferik")
         a_get("/1/lists.json").
           with(:query => {:screen_name => 'sferik', :cursor => "-1"}).
           should have_been_made
       end
-      it "should return the requested lists" do
+      it "returns the requested lists" do
         lists = @client.lists("sferik")
         lists.should be_a Twitter::Cursor
         lists.lists.should be_an Array
@@ -912,13 +912,13 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1"}).
           to_return(:body => fixture("lists.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.lists
         a_get("/1/lists.json").
           with(:query => {:cursor => "-1"}).
           should have_been_made
       end
-      it "should return the requested list" do
+      it "returns the requested list" do
         lists = @client.lists
         lists.should be_a Twitter::Cursor
         lists.lists.should be_an Array
@@ -935,13 +935,13 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list("sferik", "presidents")
         a_get("/1/lists/show.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           should have_been_made
       end
-      it "should return the updated list" do
+      it "returns the updated list" do
         list = @client.list("sferik", "presidents")
         list.should be_a Twitter::List
         list.name.should == "presidents"
@@ -953,7 +953,7 @@ describe Twitter::Client do
           with(:query => {:owner_id => '12345678', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list(12345678, 'presidents')
         a_get("/1/lists/show.json").
           with(:query => {:owner_id => '12345678', :slug => 'presidents'}).
@@ -967,7 +967,7 @@ describe Twitter::Client do
             with(:query => {:owner_id => '12345678', :slug => 'presidents'}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user = Twitter::User.new('id' => '12345678')
           @client.list(user, 'presidents')
           a_get("/1/lists/show.json").
@@ -981,7 +981,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user = Twitter::User.new('screen_name' => 'sferik')
           @client.list(user, "presidents")
           a_get("/1/lists/show.json").
@@ -998,7 +998,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list("presidents")
         a_get("/1/lists/show.json").
           with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
@@ -1011,7 +1011,7 @@ describe Twitter::Client do
           with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678'}).
           to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.list("sferik", 12345678)
         a_get("/1/lists/show.json").
           with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678'}).
@@ -1025,7 +1025,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :slug => 'presidents'}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('slug' => 'presidents', 'user' => {'screen_name' => 'sferik'})
           @client.list(list)
           a_get("/1/lists/show.json").
@@ -1039,7 +1039,7 @@ describe Twitter::Client do
             with(:query => {:owner_screen_name => 'sferik', :list_id => '12345678'}).
             to_return(:body => fixture("list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           list = Twitter::List.new('id' => '12345678', 'user' => {'screen_name' => 'sferik'})
           @client.list(list)
           a_get("/1/lists/show.json").

--- a/spec/twitter/client/local_trends_spec.rb
+++ b/spec/twitter/client/local_trends_spec.rb
@@ -12,12 +12,12 @@ describe Twitter::Client do
         stub_get("/1/trends/2487956.json").
           to_return(:body => fixture("matching_trends.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.local_trends(2487956)
         a_get("/1/trends/2487956.json").
           should have_been_made
       end
-      it "should return the top 10 trending topics for a specific WOEID" do
+      it "returns the top 10 trending topics for a specific WOEID" do
         matching_trends = @client.local_trends(2487956)
         matching_trends.should be_an Array
         matching_trends.first.should be_a Twitter::Trend
@@ -29,7 +29,7 @@ describe Twitter::Client do
         stub_get("/1/trends/1.json").
           to_return(:body => fixture("matching_trends.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.local_trends
         a_get("/1/trends/1.json").
           should have_been_made
@@ -42,12 +42,12 @@ describe Twitter::Client do
       stub_get("/1/trends/available.json").
         to_return(:body => fixture("locations.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.trend_locations
       a_get("/1/trends/available.json").
         should have_been_made
     end
-    it "should return the locations that Twitter has trending topic information for" do
+    it "returns the locations that Twitter has trending topic information for" do
       locations = @client.trend_locations
       locations.should be_an Array
       locations.first.should be_a Twitter::Place

--- a/spec/twitter/client/notification_spec.rb
+++ b/spec/twitter/client/notification_spec.rb
@@ -12,13 +12,13 @@ describe Twitter::Client do
         with(:body => {:screen_name => "sferik"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.enable_notifications("sferik")
       a_post("/1/notifications/follow.json").
         with(:body => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return an array of users" do
+    it "returns an array of users" do
       users = @client.enable_notifications("sferik")
       users.should be_an Array
       users.first.should be_a Twitter::User
@@ -32,13 +32,13 @@ describe Twitter::Client do
         with(:body => {:screen_name => "sferik"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.disable_notifications("sferik")
       a_post("/1/notifications/leave.json").
         with(:body => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return an array of users" do
+    it "returns an array of users" do
       users = @client.disable_notifications("sferik")
       users.should be_an Array
       users.first.should be_a Twitter::User

--- a/spec/twitter/client/places_and_geo_spec.rb
+++ b/spec/twitter/client/places_and_geo_spec.rb
@@ -12,13 +12,13 @@ describe Twitter::Client do
         with(:query => {:ip => "74.125.19.104"}).
         to_return(:body => fixture("places.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.places_nearby(:ip => "74.125.19.104")
       a_get("/1/geo/search.json").
         with(:query => {:ip => "74.125.19.104"}).
         should have_been_made
     end
-    it "should return nearby places" do
+    it "returns nearby places" do
       places = @client.places_nearby(:ip => "74.125.19.104")
       places.should be_an Array
       places.first.name.should == "Bernal Heights"
@@ -31,13 +31,13 @@ describe Twitter::Client do
         with(:query => {:lat => "37.7821120598956", :long => "-122.400612831116", :name => "Twitter HQ"}).
         to_return(:body => fixture("places.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.places_similar(:lat => "37.7821120598956", :long => "-122.400612831116", :name => "Twitter HQ")
       a_get("/1/geo/similar_places.json").
         with(:query => {:lat => "37.7821120598956", :long => "-122.400612831116", :name => "Twitter HQ"}).
         should have_been_made
     end
-    it "should return similar places" do
+    it "returns similar places" do
       places = @client.places_similar(:lat => "37.7821120598956", :long => "-122.400612831116", :name => "Twitter HQ")
       places.should be_an Array
       places.first.name.should == "Bernal Heights"
@@ -50,13 +50,13 @@ describe Twitter::Client do
         with(:query => {:lat => "37.7821120598956", :long => "-122.400612831116"}).
         to_return(:body => fixture("places.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.reverse_geocode(:lat => "37.7821120598956", :long => "-122.400612831116")
       a_get("/1/geo/reverse_geocode.json").
         with(:query => {:lat => "37.7821120598956", :long => "-122.400612831116"}).
         should have_been_made
     end
-    it "should return places" do
+    it "returns places" do
       places = @client.reverse_geocode(:lat => "37.7821120598956", :long => "-122.400612831116")
       places.should be_an Array
       places.first.name.should == "Bernal Heights"
@@ -68,12 +68,12 @@ describe Twitter::Client do
       stub_get("/1/geo/id/247f43d441defc03.json").
         to_return(:body => fixture("place.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.place("247f43d441defc03")
       a_get("/1/geo/id/247f43d441defc03.json").
         should have_been_made
     end
-    it "should return a place" do
+    it "returns a place" do
       place = @client.place("247f43d441defc03")
       place.name.should == "Twitter HQ"
     end
@@ -85,13 +85,13 @@ describe Twitter::Client do
         with(:body => {:name => "@sferik's Apartment", :token => "22ff5b1f7159032cf69218c4d8bb78bc", :contained_within => "41bcb736f84a799e", :lat => "37.783699", :long => "-122.393581"}).
         to_return(:body => fixture("place.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.place_create(:name => "@sferik's Apartment", :token => "22ff5b1f7159032cf69218c4d8bb78bc", :contained_within => "41bcb736f84a799e", :lat => "37.783699", :long => "-122.393581")
       a_post("/1/geo/place.json").
         with(:body => {:name => "@sferik's Apartment", :token => "22ff5b1f7159032cf69218c4d8bb78bc", :contained_within => "41bcb736f84a799e", :lat => "37.783699", :long => "-122.393581"}).
         should have_been_made
     end
-    it "should return a place" do
+    it "returns a place" do
       place = @client.place_create(:name => "@sferik's Apartment", :token => "22ff5b1f7159032cf69218c4d8bb78bc", :contained_within => "41bcb736f84a799e", :lat => "37.783699", :long => "-122.393581")
       place.name.should == "Twitter HQ"
     end

--- a/spec/twitter/client/saved_searches_spec.rb
+++ b/spec/twitter/client/saved_searches_spec.rb
@@ -12,12 +12,12 @@ describe Twitter::Client do
         stub_get("/1/saved_searches/show/16129012.json").
           to_return(:body => fixture("saved_search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.saved_searches(16129012)
         a_get("/1/saved_searches/show/16129012.json").
           should have_been_made
       end
-      it "should return an array of saved searches" do
+      it "returns an array of saved searches" do
         saved_searches = @client.saved_searches(16129012)
         saved_searches.should be_an Array
         saved_searches.first.should be_a Twitter::SavedSearch
@@ -29,12 +29,12 @@ describe Twitter::Client do
         stub_get("/1/saved_searches.json").
           to_return(:body => fixture("saved_searches.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.saved_searches
         a_get("/1/saved_searches.json").
           should have_been_made
       end
-      it "should return the authenticated user's saved search queries" do
+      it "returns the authenticated user's saved search queries" do
         saved_searches = @client.saved_searches
         saved_searches.should be_an Array
         saved_searches.first.should be_a Twitter::SavedSearch
@@ -48,12 +48,12 @@ describe Twitter::Client do
       stub_get("/1/saved_searches/show/16129012.json").
         to_return(:body => fixture("saved_search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.saved_search(16129012)
       a_get("/1/saved_searches/show/16129012.json").
         should have_been_made
     end
-    it "should return a saved search" do
+    it "returns a saved search" do
       saved_search = @client.saved_search(16129012)
       saved_search.should be_a Twitter::SavedSearch
       saved_search.name.should == "twitter"
@@ -66,13 +66,13 @@ describe Twitter::Client do
         with(:body => {:query => "twitter"}).
         to_return(:body => fixture("saved_search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.saved_search_create("twitter")
       a_post("/1/saved_searches/create.json").
         with(:body => {:query => "twitter"}).
         should have_been_made
     end
-    it "should return the created saved search" do
+    it "returns the created saved search" do
       saved_search = @client.saved_search_create("twitter")
       saved_search.should be_a Twitter::SavedSearch
       saved_search.name.should == "twitter"
@@ -84,12 +84,12 @@ describe Twitter::Client do
       stub_delete("/1/saved_searches/destroy/16129012.json").
         to_return(:body => fixture("saved_search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.saved_search_destroy(16129012)
       a_delete("/1/saved_searches/destroy/16129012.json").
         should have_been_made
     end
-    it "should return an array of deleted saved searches" do
+    it "returns an array of deleted saved searches" do
       saved_searches = @client.saved_search_destroy(16129012)
       saved_searches.should be_an Array
       saved_searches.first.should be_a Twitter::SavedSearch

--- a/spec/twitter/client/search_spec.rb
+++ b/spec/twitter/client/search_spec.rb
@@ -12,13 +12,13 @@ describe Twitter::Client do
         with(:query => {:q => "twitter"}).
         to_return(:body => fixture("/search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.search('twitter')
       a_get("/search.json").
         with(:query => {:q => "twitter"}).
         should have_been_made
     end
-    it "should return recent statuses related to a query with images and videos embedded" do
+    it "returns recent statuses related to a query with images and videos embedded" do
       search = @client.search('twitter')
       search.should be_a Twitter::SearchResults
       search.results.should be_an Array
@@ -26,7 +26,7 @@ describe Twitter::Client do
       search.results.first.text.should == "@KaiserKuo from not too far away your new twitter icon looks like Vader."
     end
 
-    it "should return the max_id value for a search result" do
+    it "returns the max_id value for a search result" do
       search = @client.search('twitter')
       search.max_id.should eq(28857935752)
     end
@@ -38,7 +38,7 @@ describe Twitter::Client do
           to_return(:body => fixture("/search_malformed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
 
-      it "should return an empty array" do
+      it "returns an empty array" do
         search = @client.search('twitter')
         search.results.should be_an Array
         search.results.should be_empty
@@ -52,13 +52,13 @@ describe Twitter::Client do
         with(:query => {:q => "twitter"}).
         to_return(:body => fixture("phoenix_search.phoenix"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.phoenix_search('twitter')
       a_get("/phoenix_search.phoenix").
         with(:query => {:q => "twitter"}).
         should have_been_made
     end
-    it "should return recent statuses related to a query with images and videos embedded" do
+    it "returns recent statuses related to a query with images and videos embedded" do
       search = @client.phoenix_search('twitter')
       search.should be_an Array
       search.first.should be_a Twitter::Status

--- a/spec/twitter/client/spam_reporting_spec.rb
+++ b/spec/twitter/client/spam_reporting_spec.rb
@@ -12,13 +12,13 @@ describe Twitter::Client do
         with(:body => {:screen_name => "sferik"}).
         to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.report_spam("sferik")
       a_post("/1/report_spam.json").
         with(:body => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return an array of users" do
+    it "returns an array of users" do
       users = @client.report_spam("sferik")
       users.should be_an Array
       users.first.should be_a Twitter::User

--- a/spec/twitter/client/suggested_users_spec.rb
+++ b/spec/twitter/client/suggested_users_spec.rb
@@ -12,12 +12,12 @@ describe Twitter::Client do
         stub_get("/1/users/suggestions/art-design.json").
           to_return(:body => fixture("category.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.suggestions("art-design")
         a_get("/1/users/suggestions/art-design.json").
           should have_been_made
       end
-      it "should return the users in a given category of the Twitter suggested user list" do
+      it "returns the users in a given category of the Twitter suggested user list" do
         suggestion = @client.suggestions("art-design")
         suggestion.should be_a Twitter::Suggestion
         suggestion.name.should == "Art & Design"
@@ -30,12 +30,12 @@ describe Twitter::Client do
         stub_get("/1/users/suggestions.json").
           to_return(:body => fixture("suggestions.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.suggestions
         a_get("/1/users/suggestions.json").
           should have_been_made
       end
-      it "should return the list of suggested user categories" do
+      it "returns the list of suggested user categories" do
         suggestions = @client.suggestions
         suggestions.should be_an Array
         suggestions.first.should be_a Twitter::Suggestion
@@ -49,12 +49,12 @@ describe Twitter::Client do
       stub_get("/1/users/suggestions/art-design/members.json").
         to_return(:body => fixture("members.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.suggest_users("art-design")
       a_get("/1/users/suggestions/art-design/members.json").
         should have_been_made
     end
-    it "should return users in a given category of the Twitter suggested user list and return their most recent status if they are not a protected user" do
+    it "returns users in a given category of the Twitter suggested user list and return their most recent status if they are not a protected user" do
       suggest_users = @client.suggest_users("art-design")
       suggest_users.should be_an Array
       suggest_users.first.should be_a Twitter::User

--- a/spec/twitter/client/timelines_spec.rb
+++ b/spec/twitter/client/timelines_spec.rb
@@ -11,12 +11,12 @@ describe Twitter::Client do
       stub_get("/1/statuses/home_timeline.json").
         to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.home_timeline
       a_get("/1/statuses/home_timeline.json").
         should have_been_made
     end
-    it "should return the 20 most recent statuses, including retweets if they exist, posted by the authenticating user and the user's they follow" do
+    it "returns the 20 most recent statuses, including retweets if they exist, posted by the authenticating user and the user's they follow" do
       statuses = @client.home_timeline
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -29,12 +29,12 @@ describe Twitter::Client do
       stub_get("/1/statuses/mentions.json").
         to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.mentions
       a_get("/1/statuses/mentions.json").
         should have_been_made
     end
-    it "should return the 20 most recent mentions (status containing @username) for the authenticating user" do
+    it "returns the 20 most recent mentions (status containing @username) for the authenticating user" do
       statuses = @client.mentions
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -49,13 +49,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.retweeted_by("sferik")
         a_get("/1/statuses/retweeted_by_user.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return the 20 most recent retweets posted by the authenticating user" do
+      it "returns the 20 most recent retweets posted by the authenticating user" do
         statuses = @client.retweeted_by("sferik")
         statuses.should be_an Array
         statuses.first.should be_a Twitter::Status
@@ -67,7 +67,7 @@ describe Twitter::Client do
         stub_get("/1/statuses/retweeted_by_me.json").
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.retweeted_by
         a_get("/1/statuses/retweeted_by_me.json").
           should have_been_made
@@ -82,13 +82,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.retweeted_to("sferik")
         a_get("/1/statuses/retweeted_to_user.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return the 20 most recent retweets posted by users the authenticating user follow" do
+      it "returns the 20 most recent retweets posted by users the authenticating user follow" do
         statuses = @client.retweeted_to("sferik")
         statuses.should be_an Array
         statuses.first.should be_a Twitter::Status
@@ -100,7 +100,7 @@ describe Twitter::Client do
         stub_get("/1/statuses/retweeted_to_me.json").
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.retweeted_to
         a_get("/1/statuses/retweeted_to_me.json").
           should have_been_made
@@ -113,12 +113,12 @@ describe Twitter::Client do
       stub_get("/1/statuses/retweets_of_me.json").
         to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.retweets_of_me
       a_get("/1/statuses/retweets_of_me.json").
         should have_been_made
     end
-    it "should return the 20 most recent tweets of the authenticated user that have been retweeted by others" do
+    it "returns the 20 most recent tweets of the authenticated user that have been retweeted by others" do
       statuses = @client.retweets_of_me
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -133,13 +133,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.user_timeline("sferik")
         a_get("/1/statuses/user_timeline.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return the 20 most recent statuses posted by the user specified by screen name or user id" do
+      it "returns the 20 most recent statuses posted by the user specified by screen name or user id" do
         statuses = @client.user_timeline("sferik")
         statuses.should be_an Array
         statuses.first.should be_a Twitter::Status
@@ -151,7 +151,7 @@ describe Twitter::Client do
         stub_get("/1/statuses/user_timeline.json").
           to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.user_timeline
         a_get("/1/statuses/user_timeline.json").
           should have_been_made
@@ -166,13 +166,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("media_timeline.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.media_timeline("sferik")
         a_get("/1/statuses/media_timeline.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return the 20 most recent images posted by the user specified by screen name or user id" do
+      it "returns the 20 most recent images posted by the user specified by screen name or user id" do
         statuses = @client.media_timeline("sferik")
         statuses.should be_an Array
         statuses.first.should be_a Twitter::Status
@@ -184,7 +184,7 @@ describe Twitter::Client do
         stub_get("/1/statuses/media_timeline.json").
           to_return(:body => fixture("media_timeline.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.media_timeline
         a_get("/1/statuses/media_timeline.json").
           should have_been_made
@@ -197,12 +197,12 @@ describe Twitter::Client do
       stub_get("/i/statuses/network_timeline.json").
         to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.network_timeline
       a_get("/i/statuses/network_timeline.json").
         should have_been_made
     end
-    it "should return the 20 most recent tweets of the authenticated user that have been retweeted by others" do
+    it "returns the 20 most recent tweets of the authenticated user that have been retweeted by others" do
       statuses = @client.network_timeline
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status

--- a/spec/twitter/client/trends_spec.rb
+++ b/spec/twitter/client/trends_spec.rb
@@ -12,13 +12,13 @@ describe Twitter::Client do
         with(:query => {:date => "2010-10-24"}).
         to_return(:body => fixture("trends_daily.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.trends_daily(Date.parse("2010-10-24"))
       a_get("/1/trends/daily.json").
         with(:query => {:date => "2010-10-24"}).
         should have_been_made
     end
-    it "should return the top 20 trending topics for each hour in a given day" do
+    it "returns the top 20 trending topics for each hour in a given day" do
       trends = @client.trends_daily(Date.parse("2010-10-24"))
       trends.should be_a Hash
       trends["2010-10-24 17:00"].should be_an Array
@@ -33,13 +33,13 @@ describe Twitter::Client do
         with(:query => {:date => "2010-10-24"}).
         to_return(:body => fixture("trends_weekly.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.trends_weekly(Date.parse("2010-10-24"))
       a_get("/1/trends/weekly.json").
         with(:query => {:date => "2010-10-24"}).
         should have_been_made
     end
-    it "should return the top 30 trending topics for each day in a given week" do
+    it "returns the top 30 trending topics for each day in a given week" do
       trends = @client.trends_weekly(Date.parse("2010-10-24"))
       trends.should be_a Hash
       trends["2010-10-24"].should be_an Array

--- a/spec/twitter/client/tweets_spec.rb
+++ b/spec/twitter/client/tweets_spec.rb
@@ -12,12 +12,12 @@ describe Twitter::Client do
         stub_get("/1/statuses/27467028175/retweeted_by/ids.json").
           to_return(:body => fixture("ids.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.retweeters_of(27467028175, :ids_only => true)
         a_get("/1/statuses/27467028175/retweeted_by/ids.json").
           should have_been_made
       end
-      it "should return an array of numeric user IDs of retweeters of a status" do
+      it "returns an array of numeric user IDs of retweeters of a status" do
         ids = @client.retweeters_of(27467028175, :ids_only => true)
         ids.should be_an Array
         ids.first.should == 47
@@ -28,12 +28,12 @@ describe Twitter::Client do
         stub_get("/1/statuses/27467028175/retweeted_by.json").
           to_return(:body => fixture("retweeters_of.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.retweeters_of(27467028175)
         a_get("/1/statuses/27467028175/retweeted_by.json").
           should have_been_made
       end
-      it "should return an array of user of retweeters of a status" do
+      it "returns an array of user of retweeters of a status" do
         users = @client.retweeters_of(27467028175)
         users.should be_an Array
         users.first.should be_a Twitter::User
@@ -47,12 +47,12 @@ describe Twitter::Client do
       stub_get("/1/statuses/retweets/28561922516.json").
         to_return(:body => fixture("retweets.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.retweets(28561922516)
       a_get("/1/statuses/retweets/28561922516.json").
         should have_been_made
     end
-    it "should return up to 100 of the first retweets of a given tweet" do
+    it "returns up to 100 of the first retweets of a given tweet" do
       statuses = @client.retweets(28561922516)
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -65,12 +65,12 @@ describe Twitter::Client do
       stub_get("/1/statuses/show/25938088801.json").
         to_return(:body => fixture("status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.status(25938088801)
       a_get("/1/statuses/show/25938088801.json").
         should have_been_made
     end
-    it "should return a status" do
+    it "returns a status" do
       status = @client.status(25938088801)
       status.should be_a Twitter::Status
       status.text.should == "@noradio working on implementing #NewTwitter API methods in the twitter gem. Twurl is making it easy. Thank you!"
@@ -82,12 +82,12 @@ describe Twitter::Client do
       stub_get("/1/statuses/show/25938088801.json").
         to_return(:body => fixture("status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.statuses(25938088801)
       a_get("/1/statuses/show/25938088801.json").
         should have_been_made
     end
-    it "should return an array of statuses" do
+    it "returns an array of statuses" do
       statuses = @client.statuses(25938088801)
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -100,12 +100,12 @@ describe Twitter::Client do
       stub_get("/i/statuses/25938088801/activity/summary.json").
         to_return(:body => fixture("activity_summary.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.status_activity(25938088801)
       a_get("/i/statuses/25938088801/activity/summary.json").
         should have_been_made
     end
-    it "should return a status" do
+    it "returns a status" do
       status = @client.status_activity(25938088801)
       status.should be_a Twitter::Status
       status.retweeters_count.should == "1"
@@ -117,12 +117,12 @@ describe Twitter::Client do
       stub_get("/i/statuses/25938088801/activity/summary.json").
         to_return(:body => fixture("activity_summary.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.statuses_activity(25938088801)
       a_get("/i/statuses/25938088801/activity/summary.json").
         should have_been_made
     end
-    it "should return an array of statuses" do
+    it "returns an array of statuses" do
       statuses = @client.statuses_activity(25938088801)
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -137,14 +137,14 @@ describe Twitter::Client do
       stub_get("/1/statuses/show/25938088801.json").
         to_return(:body => fixture("status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.status_with_activity(25938088801)
       a_get("/i/statuses/25938088801/activity/summary.json").
         should have_been_made
       a_get("/1/statuses/show/25938088801.json").
         should have_been_made
     end
-    it "should return a status" do
+    it "returns a status" do
       status = @client.status_with_activity(25938088801)
       status.should be_a Twitter::Status
       status.text.should == "@noradio working on implementing #NewTwitter API methods in the twitter gem. Twurl is making it easy. Thank you!"
@@ -159,14 +159,14 @@ describe Twitter::Client do
       stub_get("/1/statuses/show/25938088801.json").
         to_return(:body => fixture("status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.statuses_with_activity(25938088801)
       a_get("/i/statuses/25938088801/activity/summary.json").
         should have_been_made
       a_get("/1/statuses/show/25938088801.json").
         should have_been_made
     end
-    it "should return an array of statuses" do
+    it "returns an array of statuses" do
       statuses = @client.statuses_with_activity(25938088801)
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -180,12 +180,12 @@ describe Twitter::Client do
       stub_delete("/1/statuses/destroy/25938088801.json").
         to_return(:body => fixture("status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.status_destroy(25938088801)
       a_delete("/1/statuses/destroy/25938088801.json").
         should have_been_made
     end
-    it "should return an array of statuses" do
+    it "returns an array of statuses" do
       statuses = @client.status_destroy(25938088801)
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -198,12 +198,12 @@ describe Twitter::Client do
       stub_post("/1/statuses/retweet/28561922516.json").
         to_return(:body => fixture("retweet.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.retweet(28561922516)
       a_post("/1/statuses/retweet/28561922516.json").
         should have_been_made
     end
-    it "should return an array of tweets with retweet details embedded" do
+    it "returns an array of tweets with retweet details embedded" do
       statuses = @client.retweet(28561922516)
       statuses.should be_an Array
       statuses.first.should be_a Twitter::Status
@@ -219,13 +219,13 @@ describe Twitter::Client do
         with(:body => {:status => "@noradio working on implementing #NewTwitter API methods in the twitter gem. Twurl is making it easy. Thank you!"}).
         to_return(:body => fixture("status.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.update("@noradio working on implementing #NewTwitter API methods in the twitter gem. Twurl is making it easy. Thank you!")
       a_post("/1/statuses/update.json").
         with(:body => {:status => "@noradio working on implementing #NewTwitter API methods in the twitter gem. Twurl is making it easy. Thank you!"}).
         should have_been_made
     end
-    it "should return a single status" do
+    it "returns a single status" do
       status = @client.update("@noradio working on implementing #NewTwitter API methods in the twitter gem. Twurl is making it easy. Thank you!")
       status.should be_a Twitter::Status
       status.text.should == "@noradio working on implementing #NewTwitter API methods in the twitter gem. Twurl is making it easy. Thank you!"
@@ -238,61 +238,61 @@ describe Twitter::Client do
         to_return(:body => fixture("status_with_media.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
     context "a gif image" do
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.update_with_media("You always have options", fixture("pbjt.gif"))
         a_post("/1/statuses/update_with_media.json", Twitter.media_endpoint).
           should have_been_made
       end
-      it "should return a single status" do
+      it "returns a single status" do
         status = @client.update_with_media("You always have options", fixture("pbjt.gif"))
         status.should be_a Twitter::Status
         status.text.should include("You always have options")
       end
-      it 'should return the media as an entity' do
+      it 'returns the media as an entity' do
         status = @client.update_with_media("You always have options", fixture("pbjt.gif"))
         status.media.should be
       end
     end
     context "a jpe image" do
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.update_with_media("You always have options", fixture("wildcomet2.jpe"))
         a_post("/1/statuses/update_with_media.json", Twitter.media_endpoint).
           should have_been_made
       end
-      it 'should return the media as an entity' do
+      it 'returns the media as an entity' do
         status = @client.update_with_media("You always have options", fixture("wildcomet2.jpe"))
         status.media.should be
       end
     end
     context "a jpeg image" do
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.update_with_media("You always have options", fixture("me.jpeg"))
         a_post("/1/statuses/update_with_media.json", Twitter.media_endpoint).
           should have_been_made
       end
-      it 'should return the media as an entity' do
+      it 'returns the media as an entity' do
         status = @client.update_with_media("You always have options", fixture("me.jpeg"))
         status.media.should be
       end
     end
     context "a png image" do
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.update_with_media("You always have options", fixture("we_concept_bg2.png"))
         a_post("/1/statuses/update_with_media.json", Twitter.media_endpoint).
           should have_been_made
       end
-      it 'should return the media as an entity' do
+      it 'returns the media as an entity' do
         status = @client.update_with_media("You always have options", fixture("we_concept_bg2.png"))
         status.media.should be
       end
     end
     context "an IO" do
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.update_with_media("You always have options", {'io' => StringIO.new, 'type' => 'gif'})
         a_post("/1/statuses/update_with_media.json", Twitter.media_endpoint).
           should have_been_made
       end
-      it 'should return the media as an entity' do
+      it 'returns the media as an entity' do
         status = @client.update_with_media("You always have options", {'io' => StringIO.new, 'type' => 'gif'})
         status.media.should be
       end
@@ -304,12 +304,12 @@ describe Twitter::Client do
       stub_get("/1/statuses/oembed.json?id=25938088801").
         to_return(:body => fixture("oembed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.oembed(25938088801)
       a_get("/1/statuses/oembed.json?id=25938088801").
         should have_been_made
     end
-    it "should return an array of OEmbed instances" do
+    it "returns an array of OEmbed instances" do
       oembed = @client.oembed(25938088801)
       oembed.should be_a Twitter::OEmbed
     end
@@ -320,12 +320,12 @@ describe Twitter::Client do
       stub_get("/1/statuses/oembed.json?id=25938088801").
         to_return(:body => fixture("oembed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.oembeds(25938088801)
       a_get("/1/statuses/oembed.json?id=25938088801").
         should have_been_made
     end
-    it "should return an array of OEmbed instances" do
+    it "returns an array of OEmbed instances" do
       oembeds = @client.oembeds(25938088801)
       oembeds.should be_an Array
       oembeds.first.should be_a Twitter::OEmbed

--- a/spec/twitter/client/users_spec.rb
+++ b/spec/twitter/client/users_spec.rb
@@ -13,13 +13,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik,pengwynn"}).
           to_return(:body => fixture("users.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.users("sferik", "pengwynn")
         a_get("/1/users/lookup.json").
           with(:query => {:screen_name => "sferik,pengwynn"}).
           should have_been_made
       end
-      it "should return up to 100 users worth of extended information" do
+      it "returns up to 100 users worth of extended information" do
         users = @client.users("sferik", "pengwynn")
         users.should be_an Array
         users.first.should be_a Twitter::User
@@ -32,7 +32,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "0,311"}).
           to_return(:body => fixture("users.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.users("0", "311")
         a_get("/1/users/lookup.json").
           with(:query => {:screen_name => "0,311"}).
@@ -45,7 +45,7 @@ describe Twitter::Client do
           with(:query => {:user_id => "7505382,14100886"}).
           to_return(:body => fixture("users.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.users(7505382, 14100886)
         a_get("/1/users/lookup.json").
           with(:query => {:user_id => "7505382,14100886"}).
@@ -58,7 +58,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik", :user_id => "14100886"}).
           to_return(:body => fixture("users.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.users("sferik", 14100886)
         a_get("/1/users/lookup.json").
           with(:query => {:screen_name => "sferik", :user_id => "14100886"}).
@@ -72,7 +72,7 @@ describe Twitter::Client do
             with(:query => {:user_id => "7505382,14100886"}).
             to_return(:body => fixture("users.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user1 = Twitter::User.new('id' => '7505382')
           user2 = Twitter::User.new('id' => '14100886')
           @client.users(user1, user2)
@@ -87,7 +87,7 @@ describe Twitter::Client do
             with(:query => {:screen_name => "sferik,pengwynn"}).
             to_return(:body => fixture("users.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user1 = Twitter::User.new('screen_name' => 'sferik')
           user2 = Twitter::User.new('screen_name' => 'pengwynn')
           @client.users(user1, user2)
@@ -102,7 +102,7 @@ describe Twitter::Client do
             with(:query => {:screen_name => "sferik", :user_id => "14100886"}).
             to_return(:body => fixture("users.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user1 = Twitter::User.new('screen_name' => 'sferik')
           user2 = Twitter::User.new('id' => '14100886')
           @client.users(user1, user2)
@@ -120,7 +120,7 @@ describe Twitter::Client do
         stub_get("/1/users/profile_image/sferik").
           to_return(fixture("profile_image.text"))
       end
-      it "should redirect to the correct resource" do
+      it "redirects to the correct resource" do
         profile_image = @client.profile_image("sferik")
         a_get("/1/users/profile_image/sferik").
           with(:status => 302).
@@ -135,7 +135,7 @@ describe Twitter::Client do
         stub_get("/1/users/profile_image/sferik").
           to_return(fixture("profile_image.text"))
       end
-      it "should redirect to the correct resource" do
+      it "redirects to the correct resource" do
         profile_image = @client.profile_image
         a_get("/1/users/profile_image/sferik").
           with(:status => 302).
@@ -148,7 +148,7 @@ describe Twitter::Client do
         stub_get("/1/users/profile_image/sferik").
           to_return(fixture("profile_image.text"))
       end
-      it "should redirect to the correct resource" do
+      it "redirects to the correct resource" do
         user = Twitter::User.new('screen_name' => 'sferik')
         profile_image = @client.profile_image(user)
         a_get("/1/users/profile_image/sferik").
@@ -165,13 +165,13 @@ describe Twitter::Client do
         with(:query => {:q => "Erik Michaels-Ober"}).
         to_return(:body => fixture("user_search.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.user_search("Erik Michaels-Ober")
       a_get("/1/users/search.json").
         with(:query => {:q => "Erik Michaels-Ober"}).
         should have_been_made
     end
-    it "should return an array of user search results" do
+    it "returns an array of user search results" do
       user_search = @client.user_search("Erik Michaels-Ober")
       user_search.should be_an Array
       user_search.first.should be_a Twitter::User
@@ -186,13 +186,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.user("sferik")
         a_get("/1/users/show.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return extended information of a given user" do
+      it "returns extended information of a given user" do
         user = @client.user("sferik")
         user.should be_a Twitter::User
         user.name.should == "Erik Michaels-Ober"
@@ -204,7 +204,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "@sferik"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.user("@sferik")
         a_get("/1/users/show.json").
           with(:query => {:screen_name => "@sferik"}).
@@ -217,7 +217,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "0"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.user("0")
         a_get("/1/users/show.json").
           with(:query => {:screen_name => "0"}).
@@ -230,7 +230,7 @@ describe Twitter::Client do
           with(:query => {:user_id => "7505382"}).
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.user(7505382)
         a_get("/1/users/show.json").
           with(:query => {:user_id => "7505382"}).
@@ -244,7 +244,7 @@ describe Twitter::Client do
             with(:query => {:user_id => "7505382"}).
             to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user = Twitter::User.new('id' => 7505382)
           @client.user(user)
           a_get("/1/users/show.json").
@@ -258,7 +258,7 @@ describe Twitter::Client do
             with(:query => {:screen_name => "sferik"}).
             to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
         end
-        it "should request the correct resource" do
+        it "requests the correct resource" do
           user = Twitter::User.new('screen_name' => 'sferik')
           @client.user(user)
           a_get("/1/users/show.json").
@@ -272,7 +272,7 @@ describe Twitter::Client do
         stub_get("/1/account/verify_credentials.json").
           to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.user
         a_get("/1/account/verify_credentials.json").
           should have_been_made
@@ -289,17 +289,17 @@ describe Twitter::Client do
         with(:query => {:screen_name => "pengwynn"}).
         to_return(:body => fixture("not_found.json"), :status => 404, :headers => {:content_type => "application/json; charset=utf-8"})
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @client.user?("sferik")
       a_get("/1/users/show.json").
         with(:query => {:screen_name => "sferik"}).
         should have_been_made
     end
-    it "should return true if user exists" do
+    it "returns true if user exists" do
       user = @client.user?("sferik")
       user.should be_true
     end
-    it "should return false if user does not exist" do
+    it "returns false if user does not exist" do
       user = @client.user?("pengwynn")
       user.should be_false
     end
@@ -312,13 +312,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("contributees.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.contributees("sferik")
         a_get("/1/users/contributees.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return a user's contributees" do
+      it "returns a user's contributees" do
         contributees = @client.contributees("sferik")
         contributees.should be_an Array
         contributees.first.should be_a Twitter::User
@@ -333,13 +333,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("contributees.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.contributees
         a_get("/1/users/contributees.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return a user's contributees" do
+      it "returns a user's contributees" do
         contributees = @client.contributees
         contributees.should be_an Array
         contributees.first.should be_a Twitter::User
@@ -357,13 +357,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("contributors.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.contributors("sferik")
         a_get("/1/users/contributors.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return a user's contributors" do
+      it "returns a user's contributors" do
         contributors = @client.contributors("sferik")
         contributors.should be_an Array
         contributors.first.should be_a Twitter::User
@@ -378,13 +378,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("contributors.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.contributors
         a_get("/1/users/contributors.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return a user's contributors" do
+      it "returns a user's contributors" do
         contributors = @client.contributors
         contributors.should be_an Array
         contributors.first.should be_a Twitter::User
@@ -400,13 +400,13 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("recommendations.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.recommendations("sferik")
         a_get("/1/users/recommendations.json").
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return recommended users for the authenticated user" do
+      it "returns recommended users for the authenticated user" do
         recommendations = @client.recommendations("sferik")
         recommendations.should be_an Array
         recommendations.first.should be_a Twitter::User
@@ -421,7 +421,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           to_return(:body => fixture("recommendations.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.recommendations
         a_get("/1/account/verify_credentials.json").
           should have_been_made
@@ -429,7 +429,7 @@ describe Twitter::Client do
           with(:query => {:screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return recommended users for the authenticated user" do
+      it "returns recommended users for the authenticated user" do
         recommendations = @client.recommendations
         recommendations.should be_an Array
         recommendations.first.should be_a Twitter::User
@@ -445,13 +445,13 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1", :screen_name => "sferik"}).
           to_return(:body => fixture("users_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.following_followers_of("sferik")
         a_get("/users/following_followers_of.json").
           with(:query => {:cursor => "-1", :screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return an array of numeric IDs for every user following the specified user" do
+      it "returns an array of numeric IDs for every user following the specified user" do
         following_followers_of = @client.following_followers_of("sferik")
         following_followers_of.should be_a Twitter::Cursor
         following_followers_of.users.should be_an Array
@@ -466,7 +466,7 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1", :screen_name => "sferik"}).
           to_return(:body => fixture("users_list.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       end
-      it "should request the correct resource" do
+      it "requests the correct resource" do
         @client.following_followers_of
         a_get("/1/account/verify_credentials.json").
           should have_been_made
@@ -474,7 +474,7 @@ describe Twitter::Client do
           with(:query => {:cursor => "-1", :screen_name => "sferik"}).
           should have_been_made
       end
-      it "should return an array of numeric IDs for every user following the specified user" do
+      it "returns an array of numeric IDs for every user following the specified user" do
         following_followers_of = @client.following_followers_of
         following_followers_of.should be_a Twitter::Cursor
         following_followers_of.users.should be_an Array

--- a/spec/twitter/client_spec.rb
+++ b/spec/twitter/client_spec.rb
@@ -19,7 +19,7 @@ describe Twitter::Client do
       Twitter.reset
     end
 
-    it "should inherit module configuration" do
+    it "inherits the module configuration" do
       api = Twitter::Client.new
       @keys.each do |key|
         api.send(key).should == key
@@ -44,7 +44,7 @@ describe Twitter::Client do
       end
 
       context "during initialization" do
-        it "should override module configuration" do
+        it "overrides the module configuration" do
           api = Twitter::Client.new(@configuration)
           @keys.each do |key|
             api.send(key).should == @configuration[key]
@@ -53,7 +53,7 @@ describe Twitter::Client do
       end
 
       context "after initilization" do
-        it "should override module configuration after initialization" do
+        it "overrides the module configuration after initialization" do
           api = Twitter::Client.new
           @configuration.each do |key, value|
             api.send("#{key}=", value)
@@ -67,7 +67,7 @@ describe Twitter::Client do
     end
   end
 
-  it "should not cache the screen name across clients" do
+  it "does not cache the screen name across clients" do
     stub_get("/1/account/verify_credentials.json").
       to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     client1 = Twitter::Client.new
@@ -78,7 +78,7 @@ describe Twitter::Client do
     client2.current_user.screen_name.should == 'pengwynn'
   end
 
-  it "should recursively merge connection options" do
+  it "recursively merges connection options" do
     stub_get("/1/statuses/user_timeline.json").
       with(:query => {:screen_name => "sferik"}, :headers => {"Accept" => "application/json", "User-Agent" => "Custom User Agent"}).
       to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})

--- a/spec/twitter/configuration_spec.rb
+++ b/spec/twitter/configuration_spec.rb
@@ -3,12 +3,12 @@ require 'helper'
 describe Twitter::Configuration do
 
   describe "#photo_sizes" do
-    it "should return a hash of sizes when photo_sizes is set" do
+    it "returns a hash of sizes when photo_sizes is set" do
       photo_sizes = Twitter::Configuration.new('photo_sizes' => {'small' => {'h' => 226, 'w' => 340, 'resize' => 'fit'}, 'large' => {'h' => 466, 'w' => 700, 'resize' => 'fit'}, 'medium' => {'h' => 399, 'w' => 600, 'resize' => 'fit'}, 'thumb' => {'h' => 150, 'w' => 150, 'resize' => 'crop'}}).photo_sizes
       photo_sizes.should be_a Hash
       photo_sizes['small'].should be_a Twitter::Size
     end
-    it "should be empty when photo_sizes is not set" do
+    it "is empty when photo_sizes is not set" do
       photo_sizes = Twitter::Configuration.new().photo_sizes
       photo_sizes.should be_empty
     end

--- a/spec/twitter/cursor_spec.rb
+++ b/spec/twitter/cursor_spec.rb
@@ -7,7 +7,7 @@ describe Twitter::Cursor do
       before do
         @cursor = Twitter::Cursor.new({'previous_cursor' => 0}, 'ids')
       end
-      it "should return true" do
+      it "returns true" do
         @cursor.first?.should be_true
       end
     end
@@ -15,7 +15,7 @@ describe Twitter::Cursor do
       before do
         @cursor = Twitter::Cursor.new({'previous_cursor' => 1}, 'ids')
       end
-      it "should return true" do
+      it "returns true" do
         @cursor.first?.should be_false
       end
     end
@@ -26,7 +26,7 @@ describe Twitter::Cursor do
       before do
         @cursor = Twitter::Cursor.new({'next_cursor' => 0}, 'ids')
       end
-      it "should return true" do
+      it "returns true" do
         @cursor.last?.should be_true
       end
     end
@@ -34,7 +34,7 @@ describe Twitter::Cursor do
       before do
         @cursor = Twitter::Cursor.new({'next_cursor' => 1}, 'ids')
       end
-      it "should return false" do
+      it "returns false" do
         @cursor.last?.should be_false
       end
     end

--- a/spec/twitter/direct_message_spec.rb
+++ b/spec/twitter/direct_message_spec.rb
@@ -3,17 +3,17 @@ require 'helper'
 describe Twitter::DirectMessage do
 
   describe "#==" do
-    it "should return true when ids and classes are equal" do
+    it "returns true when ids and classes are equal" do
       direct_message = Twitter::DirectMessage.new('id' => 1)
       other = Twitter::DirectMessage.new('id' => 1)
       (direct_message == other).should be_true
     end
-    it "should return false when classes are not equal" do
+    it "returns false when classes are not equal" do
       direct_message = Twitter::DirectMessage.new('id' => 1)
       other = Twitter::User.new('id' => 1)
       (direct_message == other).should be_false
     end
-    it "should return false when ids are not equal" do
+    it "returns false when ids are not equal" do
       direct_message = Twitter::DirectMessage.new('id' => 1)
       other = Twitter::DirectMessage.new('id' => 2)
       (direct_message == other).should be_false
@@ -21,33 +21,33 @@ describe Twitter::DirectMessage do
   end
 
   describe "#created_at" do
-    it "should return a Time when created_at is set" do
+    it "returns a Time when created_at is set" do
       direct_message = Twitter::DirectMessage.new('created_at' => "Mon Jul 16 12:59:01 +0000 2007")
       direct_message.created_at.should be_a Time
     end
-    it "should return nil when created_at is not set" do
+    it "returns nil when created_at is not set" do
       direct_message = Twitter::DirectMessage.new
       direct_message.created_at.should be_nil
     end
   end
 
   describe "#recipient" do
-    it "should return a User when recipient is set" do
+    it "returns a User when recipient is set" do
       recipient = Twitter::DirectMessage.new('recipient' => {}).recipient
       recipient.should be_a Twitter::User
     end
-    it "should return nil when status is not set" do
+    it "returns nil when status is not set" do
       recipient = Twitter::DirectMessage.new.recipient
       recipient.should be_nil
     end
   end
 
   describe "#sender" do
-    it "should return a User when sender is set" do
+    it "returns a User when sender is set" do
       sender = Twitter::DirectMessage.new('sender' => {}).sender
       sender.should be_a Twitter::User
     end
-    it "should return nil when status is not set" do
+    it "returns nil when status is not set" do
       sender = Twitter::DirectMessage.new.sender
       sender.should be_nil
     end

--- a/spec/twitter/error_spec.rb
+++ b/spec/twitter/error_spec.rb
@@ -3,7 +3,7 @@ require 'helper'
 describe Twitter::Error do
 
   describe "#initialize" do
-    it "should wrap another error class" do
+    it "wraps another error class" do
       begin
         raise Faraday::Error::ClientError.new("Oups")
       rescue Faraday::Error::ClientError
@@ -18,48 +18,48 @@ describe Twitter::Error do
   end
 
   describe "#ratelimit_reset" do
-    it "should return a Time when X-RateLimit-Reset header is set" do
+    it "returns a Time when X-RateLimit-Reset header is set" do
       error = Twitter::Error.new("Error", {'X-RateLimit-Reset' => "1339019097"})
       error.ratelimit_reset.should be_a Time
       error.ratelimit_reset.should == Time.at(1339019097)
     end
-    it "should return nil when X-RateLimit-Reset header is not set" do
+    it "returns nil when X-RateLimit-Reset header is not set" do
       error = Twitter::Error.new("Error", {})
       error.ratelimit_reset.should be_nil
     end
   end
 
   describe "#ratelimit_class" do
-    it "should return a String when X-RateLimit-Class header is set" do
+    it "returns a String when X-RateLimit-Class header is set" do
       error = Twitter::Error.new("Error", {'X-RateLimit-Class' => "api"})
       error.ratelimit_class.should be_an String
       error.ratelimit_class.should == "api"
     end
-    it "should return nil when X-RateLimit-Class header is not set" do
+    it "returns nil when X-RateLimit-Class header is not set" do
       error = Twitter::Error.new("Error", {})
       error.ratelimit_class.should be_nil
     end
   end
 
   describe "#ratelimit_limit" do
-    it "should return an Integer when X-RateLimit-Limit header is set" do
+    it "returns an Integer when X-RateLimit-Limit header is set" do
       error = Twitter::Error.new("Error", {'X-RateLimit-Limit' => "150"})
       error.ratelimit_limit.should be_an Integer
       error.ratelimit_limit.should == 150
     end
-    it "should return nil when X-RateLimit-Limit header is not set" do
+    it "returns nil when X-RateLimit-Limit header is not set" do
       error = Twitter::Error.new("Error", {})
       error.ratelimit_limit.should be_nil
     end
   end
 
   describe "#ratelimit_remaining" do
-    it "should return an Integer when X-RateLimit-Remaining header is set" do
+    it "returns an Integer when X-RateLimit-Remaining header is set" do
       error = Twitter::Error.new("Error", {'X-RateLimit-Remaining' => "149"})
       error.ratelimit_remaining.should be_an Integer
       error.ratelimit_remaining.should == 149
     end
-    it "should return nil when X-RateLimit-Remaining header is not set" do
+    it "returns nil when X-RateLimit-Remaining header is not set" do
       error = Twitter::Error.new("Error", {})
       error.ratelimit_remaining.should be_nil
     end
@@ -72,12 +72,12 @@ describe Twitter::Error do
     after do
       Timecop.return
     end
-    it "should return an Integer when X-RateLimit-Reset header is set" do
+    it "returns an Integer when X-RateLimit-Reset header is set" do
       error = Twitter::Error.new("Error", {'X-RateLimit-Reset' => "1339019097"})
       error.retry_after.should be_an Integer
       error.retry_after.should == 15777
     end
-    it "should return nil when X-RateLimit-Reset header is not set" do
+    it "returns nil when X-RateLimit-Reset header is not set" do
       error = Twitter::Error.new("Error", {})
       error.retry_after.should be_nil
     end

--- a/spec/twitter/favorite_spec.rb
+++ b/spec/twitter/favorite_spec.rb
@@ -3,24 +3,24 @@ require 'helper'
 describe Twitter::Favorite do
 
   describe "#sources" do
-    it "should return a collection of users who favorited a status" do
+    it "returns a collection of users who favorited a status" do
       sources = Twitter::Favorite.new('sources' => [{}]).sources
       sources.should be_an Array
       sources.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       sources = Twitter::Favorite.new.sources
       sources.should be_empty
     end
   end
 
   describe "#targets" do
-    it "should return a collection containing the favorited status" do
+    it "returns a collection containing the favorited status" do
       targets = Twitter::Favorite.new('targets' => [{}]).targets
       targets.should be_an Array
       targets.first.should be_a Twitter::Status
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::Favorite.new.targets
       targets.should be_empty
     end

--- a/spec/twitter/follow_spec.rb
+++ b/spec/twitter/follow_spec.rb
@@ -3,24 +3,24 @@ require 'helper'
 describe Twitter::Follow do
 
   describe "#sources" do
-    it "should return a collection of users who followed a user" do
+    it "returns a collection of users who followed a user" do
       sources = Twitter::Follow.new('sources' => [{}]).sources
       sources.should be_an Array
       sources.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       sources = Twitter::Follow.new.sources
       sources.should be_empty
     end
   end
 
   describe "#targets" do
-    it "should return a collection containing the followed user" do
+    it "returns a collection containing the followed user" do
       targets = Twitter::Follow.new('targets' => [{}]).targets
       targets.should be_an Array
       targets.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::Follow.new.targets
       targets.should be_empty
     end

--- a/spec/twitter/geo_factory_spec.rb
+++ b/spec/twitter/geo_factory_spec.rb
@@ -3,15 +3,15 @@ require 'helper'
 describe Twitter::GeoFactory do
 
   describe ".new" do
-    it "should generate a Point" do
+    it "generates a Point" do
       geo = Twitter::GeoFactory.new('type' => 'Point')
       geo.should be_a Twitter::Point
     end
-    it "should generate a Polygon" do
+    it "generates a Polygon" do
       geo = Twitter::GeoFactory.new('type' => 'Polygon')
       geo.should be_a Twitter::Polygon
     end
-    it "should raise an ArgumentError when type is not specified" do
+    it "raises an ArgumentError when type is not specified" do
       lambda do
         Twitter::GeoFactory.new({})
       end.should raise_error(ArgumentError, "argument must have a 'type' key")

--- a/spec/twitter/list_member_added_spec.rb
+++ b/spec/twitter/list_member_added_spec.rb
@@ -3,36 +3,36 @@ require 'helper'
 describe Twitter::ListMemberAdded do
 
   describe "#sources" do
-    it "should return a collection of users who added a user to a list" do
+    it "returns a collection of users who added a user to a list" do
       sources = Twitter::ListMemberAdded.new('sources' => [{}]).sources
       sources.should be_an Array
       sources.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       sources = Twitter::ListMemberAdded.new.sources
       sources.should be_empty
     end
   end
 
   describe "#target_objects" do
-    it "should return a collection of lists that were added to" do
+    it "returns a collection of lists that were added to" do
       targets = Twitter::ListMemberAdded.new('target_objects' => [{}]).target_objects
       targets.should be_an Array
       targets.first.should be_a Twitter::List
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::ListMemberAdded.new.target_objects
       targets.should be_empty
     end
   end
 
   describe "#targets" do
-    it "should return a collection of users who were added to a list" do
+    it "returns a collection of users who were added to a list" do
       targets = Twitter::ListMemberAdded.new('targets' => [{}]).targets
       targets.should be_an Array
       targets.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::ListMemberAdded.new.targets
       targets.should be_empty
     end

--- a/spec/twitter/list_spec.rb
+++ b/spec/twitter/list_spec.rb
@@ -3,17 +3,17 @@ require 'helper'
 describe Twitter::List do
 
   describe "#==" do
-    it "should return true when ids and classes are equal" do
+    it "returns true when ids and classes are equal" do
       list = Twitter::List.new('id' => 1)
       other = Twitter::List.new('id' => 1)
       (list == other).should be_true
     end
-    it "should return false when classes are not equal" do
+    it "returns false when classes are not equal" do
       list = Twitter::List.new('id' => 1)
       other = Twitter::User.new('id' => 1)
       (list == other).should be_false
     end
-    it "should return false when ids are not equal" do
+    it "returns false when ids are not equal" do
       list = Twitter::List.new('id' => 1)
       other = Twitter::List.new('id' => 2)
       (list == other).should be_false
@@ -21,22 +21,22 @@ describe Twitter::List do
   end
 
   describe "#created_at" do
-    it "should return a Time when created_at is set" do
+    it "returns a Time when created_at is set" do
       user = Twitter::List.new('created_at' => "Mon Jul 16 12:59:01 +0000 2007")
       user.created_at.should be_a Time
     end
-    it "should return nil when created_at is not set" do
+    it "returns nil when created_at is not set" do
       user = Twitter::List.new
       user.created_at.should be_nil
     end
   end
 
   describe "#user" do
-    it "should return a User when user is set" do
+    it "returns a User when user is set" do
       user = Twitter::List.new('user' => {}).user
       user.should be_a Twitter::User
     end
-    it "should return nil when status is not set" do
+    it "returns nil when status is not set" do
       user = Twitter::List.new.user
       user.should be_nil
     end

--- a/spec/twitter/media_factory_spec.rb
+++ b/spec/twitter/media_factory_spec.rb
@@ -3,11 +3,11 @@ require 'helper'
 describe Twitter::MediaFactory do
 
   describe ".new" do
-    it "should generate a Photo" do
+    it "generates a Photo" do
       media = Twitter::MediaFactory.new('type' => 'photo')
       media.should be_a Twitter::Photo
     end
-    it "should raise an ArgumentError when type is not specified" do
+    it "raises an ArgumentError when type is not specified" do
       lambda do
         Twitter::MediaFactory.new({})
       end.should raise_error(ArgumentError, "argument must have a 'type' key")

--- a/spec/twitter/mention_spec.rb
+++ b/spec/twitter/mention_spec.rb
@@ -3,47 +3,47 @@ require 'helper'
 describe Twitter::Mention do
 
   describe "#sources" do
-    it "should return a collection of users who mentioned a user" do
+    it "returns a collection of users who mentioned a user" do
       sources = Twitter::Mention.new('sources' => [{}]).sources
       sources.should be_an Array
       sources.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       sources = Twitter::Mention.new.sources
       sources.should be_empty
     end
   end
 
   describe "#source" do
-    it "should return the user who mentioned a user" do
+    it "returns the user who mentioned a user" do
       source = Twitter::Mention.new('sources' => [{}]).source
       source.should be_a Twitter::User
     end
-    it "should be nil when not set" do
+    it "returns nil when not set" do
       source = Twitter::Mention.new.source
       source.should be_nil
     end
   end
 
   describe "#target_objects" do
-    it "should return a collection of statuses that mention a user" do
+    it "returns a collection of statuses that mention a user" do
       targets = Twitter::Mention.new('target_objects' => [{}]).target_objects
       targets.should be_an Array
       targets.first.should be_a Twitter::Status
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::Mention.new.target_objects
       targets.should be_empty
     end
   end
 
   describe "#targets" do
-    it "should return a collection containing the mentioned user" do
+    it "returns a collection containing the mentioned user" do
       targets = Twitter::Mention.new('targets' => [{}]).targets
       targets.should be_an Array
       targets.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::Mention.new.targets
       targets.should be_empty
     end

--- a/spec/twitter/oembed_spec.rb
+++ b/spec/twitter/oembed_spec.rb
@@ -2,142 +2,142 @@ require 'helper'
 
 describe Twitter::OEmbed do
   describe "#author_url" do
-    it "should return the author's url" do
+    it "returns the author's url" do
       oembed = Twitter::OEmbed.new('author_url' => 'https://twitter.com/sferik')
       oembed.author_url.should == "https://twitter.com/sferik"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       author_url = Twitter::OEmbed.new.author_url
       author_url.should be_nil
     end
   end
 
   describe "#author_name" do
-    it "should return the author's name" do
+    it "returns the author's name" do
       oembed = Twitter::OEmbed.new('author_name' => 'Erik Michaels-Ober')
       oembed.author_name.should == "Erik Michaels-Ober"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       author_name = Twitter::OEmbed.new.author_name
       author_name.should be_nil
     end
   end
 
   describe "#cache_age" do
-    it "should return the cache_age" do
+    it "returns the cache_age" do
       oembed = Twitter::OEmbed.new('cache_age' => '31536000000')
       oembed.cache_age.should == "31536000000"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       cache_age = Twitter::OEmbed.new.cache_age
       cache_age.should be_nil
     end
   end
 
   describe "#height" do
-    it "should return the height" do
+    it "returns the height" do
       oembed = Twitter::OEmbed.new('height' => 200)
       oembed.height.should == 200
     end
 
-    it "should return it as an Integer" do
+    it "returns it as an Integer" do
       oembed = Twitter::OEmbed.new('height' => 200)
       oembed.height.should be_an Integer
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       height = Twitter::OEmbed.new.height
       height.should be_nil
     end
   end
 
   describe "#html" do
-    it "should return the html" do
+    it "returns the html" do
       oembed = Twitter::OEmbed.new('html' => '<blockquote>all my <b>witty tweet</b> stuff here</blockquote>')
       oembed.html.should == "<blockquote>all my <b>witty tweet</b> stuff here</blockquote>"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       html = Twitter::OEmbed.new.html
       html.should be_nil
     end
   end
 
   describe "#provider_name" do
-    it "should return the provider_name" do
+    it "returns the provider_name" do
       oembed = Twitter::OEmbed.new('provider_name' => 'Twitter')
       oembed.provider_name.should == "Twitter"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       provider_name = Twitter::OEmbed.new.provider_name
       provider_name.should be_nil
     end
   end
 
   describe "#provider_url" do
-    it "should return the provider_url" do
+    it "returns the provider_url" do
       oembed = Twitter::OEmbed.new('provider_url' => 'http://twitter.com')
       oembed.provider_url.should == "http://twitter.com"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       provider_url = Twitter::OEmbed.new.provider_url
       provider_url.should be_nil
     end
   end
 
   describe "#type" do
-    it "should return the type" do
+    it "returns the type" do
       oembed = Twitter::OEmbed.new('type' => 'rich')
       oembed.type.should == "rich"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       type = Twitter::OEmbed.new.type
       type.should be_nil
     end
   end
 
   describe "#width" do
-    it "should return the width" do
+    it "returns the width" do
       oembed = Twitter::OEmbed.new('width' => 550)
       oembed.width.should == 550
     end
 
-    it "should return it as an Integer" do
+    it "returns it as an Integer" do
       oembed = Twitter::OEmbed.new('width' => 550)
       oembed.width.should be_an Integer
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       width = Twitter::OEmbed.new.width
       width.should be_nil
     end
   end
 
   describe "#url" do
-    it "should return the url" do
+    it "returns the url" do
       oembed = Twitter::OEmbed.new('url' => 'https://twitter.com/twitterapi/status/133640144317198338')
       oembed.url.should == "https://twitter.com/twitterapi/status/133640144317198338"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       url = Twitter::OEmbed.new.url
       url.should be_nil
     end
   end
 
   describe "#version" do
-    it "should return the version" do
+    it "returns the version" do
       oembed = Twitter::OEmbed.new('version' => '1.0')
       oembed.version.should == "1.0"
     end
 
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       version = Twitter::OEmbed.new.version
       version.should be_nil
     end

--- a/spec/twitter/photo_spec.rb
+++ b/spec/twitter/photo_spec.rb
@@ -3,17 +3,17 @@ require 'helper'
 describe Twitter::Photo do
 
   describe "#==" do
-    it "should return true when ids and classes are equal" do
+    it "returns true when ids and classes are equal" do
       photo = Twitter::Photo.new('id' => 1)
       other = Twitter::Photo.new('id' => 1)
       (photo == other).should be_true
     end
-    it "should return false when classes are not equal" do
+    it "returns false when classes are not equal" do
       photo = Twitter::Photo.new('id' => 1)
       other = Twitter::User.new('id' => 1)
       (photo == other).should be_false
     end
-    it "should return false when ids are not equal" do
+    it "returns false when ids are not equal" do
       photo = Twitter::Photo.new('id' => 1)
       other = Twitter::Photo.new('id' => 2)
       (photo == other).should be_false
@@ -21,12 +21,12 @@ describe Twitter::Photo do
   end
 
   describe "#sizes" do
-    it "should return a hash of Sizes when sizes is set" do
+    it "returns a hash of Sizes when sizes is set" do
       sizes = Twitter::Photo.new('sizes' => {'small' => {'h' => 226, 'w' => 340, 'resize' => 'fit'}, 'large' => {'h' => 466, 'w' => 700, 'resize' => 'fit'}, 'medium' => {'h' => 399, 'w' => 600, 'resize' => 'fit'}, 'thumb' => {'h' => 150, 'w' => 150, 'resize' => 'crop'}}).sizes
       sizes.should be_a Hash
       sizes['small'].should be_a Twitter::Size
     end
-    it "should be empty when sizes is not set" do
+    it "is empty when sizes is not set" do
       sizes = Twitter::Photo.new.sizes
       sizes.should be_empty
     end

--- a/spec/twitter/place_spec.rb
+++ b/spec/twitter/place_spec.rb
@@ -3,17 +3,17 @@ require 'helper'
 describe Twitter::Place do
 
   describe "#==" do
-    it "should return true when ids and classes are equal" do
+    it "returns true when ids and classes are equal" do
       place = Twitter::Place.new('id' => 1)
       other = Twitter::Place.new('id' => 1)
       (place == other).should be_true
     end
-    it "should return false when classes are not equal" do
+    it "returns false when classes are not equal" do
       place = Twitter::Place.new('id' => 1)
       other = Twitter::User.new('id' => 1)
       (place == other).should be_false
     end
-    it "should return false when ids are not equal" do
+    it "returns false when ids are not equal" do
       place = Twitter::Place.new('id' => 1)
       other = Twitter::Place.new('id' => 2)
       (place == other).should be_false
@@ -21,52 +21,52 @@ describe Twitter::Place do
   end
 
   describe "#bounding_box" do
-    it "should return a Twitter::Place when set" do
+    it "returns a Twitter::Place when set" do
       place = Twitter::Place.new('bounding_box' => {'type' => 'Polygon', 'coordinates' => [[[-122.40348192, 37.77752898], [-122.387436, 37.77752898], [-122.387436, 37.79448597], [-122.40348192, 37.79448597]]]})
       place.bounding_box.should be_a Twitter::Polygon
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       place = Twitter::Place.new
       place.bounding_box.should be_nil
     end
   end
 
   describe "#country_code" do
-    it "should return a country code when set with country_code" do
+    it "returns a country code when set with country_code" do
       place = Twitter::Place.new('country_code' => 'US')
       place.country_code.should == 'US'
     end
-    it "should return a country code when set with countryCode" do
+    it "returns a country code when set with countryCode" do
       place = Twitter::Place.new('countryCode' => 'US')
       place.country_code.should == 'US'
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       place = Twitter::Place.new
       place.country_code.should be_nil
     end
   end
 
   describe "#parent_id" do
-    it "should return a parent ID when set with parentid" do
+    it "returns a parent ID when set with parentid" do
       place = Twitter::Place.new('parentid' => 1)
       place.parent_id.should == 1
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       place = Twitter::Place.new
       place.parent_id.should be_nil
     end
   end
 
   describe "#place_type" do
-    it "should return a place type when set with place_type" do
+    it "returns a place type when set with place_type" do
       place = Twitter::Place.new('place_type' => 'city')
       place.place_type.should == 'city'
     end
-    it "should return a place type when set with placeType[name]" do
+    it "returns a place type when set with placeType[name]" do
       place = Twitter::Place.new('placeType' => {'name' => 'Town'})
       place.place_type.should == 'Town'
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       place = Twitter::Place.new
       place.place_type.should be_nil
     end

--- a/spec/twitter/point_spec.rb
+++ b/spec/twitter/point_spec.rb
@@ -7,24 +7,24 @@ describe Twitter::Point do
   end
 
   describe "#==" do
-    it "should return true when coordinates are equal" do
+    it "returns true when coordinates are equal" do
       other = Twitter::Point.new('coordinates' => [-122.399983, 37.788299])
       (@point == other).should be_true
     end
-    it "should return false when coordinates are not equal" do
+    it "returns false when coordinates are not equal" do
       other = Twitter::Point.new('coordinates' => [37.788299, -122.399983])
       (@point == other).should be_false
     end
   end
 
   describe "#latitude" do
-    it "should return the latitude" do
+    it "returns the latitude" do
       @point.latitude.should == -122.399983
     end
   end
 
   describe "#longitude" do
-    it "should return the longitude" do
+    it "returns the longitude" do
       @point.longitude.should == 37.788299
     end
   end

--- a/spec/twitter/polygon_spec.rb
+++ b/spec/twitter/polygon_spec.rb
@@ -5,11 +5,11 @@ describe Twitter::Polygon do
   end
 
   describe "#==" do
-    it "should return true when coordinates are equal" do
+    it "returns true when coordinates are equal" do
       other = Twitter::Polygon.new('coordinates' => [[[-122.40348192, 37.77752898], [-122.387436, 37.77752898], [-122.387436, 37.79448597], [-122.40348192, 37.79448597]]])
       (@polygon == other).should be_true
     end
-    it "should return false when coordinates are not equal" do
+    it "returns false when coordinates are not equal" do
       other = Twitter::Polygon.new('coordinates' => [[[37.77752898, -122.40348192], [37.77752898, -122.387436], [37.79448597, -122.387436], [37.79448597, -122.40348192]]])
       (@polygon == other).should be_false
     end

--- a/spec/twitter/rate_limit_status_spec.rb
+++ b/spec/twitter/rate_limit_status_spec.rb
@@ -3,11 +3,11 @@ require 'helper'
 describe Twitter::RateLimitStatus do
 
   describe "#reset_time" do
-    it "should return a Time when reset_time is set" do
+    it "returns a Time when reset_time is set" do
       rate_limit_status = Twitter::RateLimitStatus.new('reset_time' => "Mon Jul 16 12:59:01 +0000 2007")
       rate_limit_status.reset_time.should be_a Time
     end
-    it "should return nil when reset_time is not set" do
+    it "returns nil when reset_time is not set" do
       rate_limit_status = Twitter::RateLimitStatus.new
       rate_limit_status.reset_time.should be_nil
     end

--- a/spec/twitter/relationship_spec.rb
+++ b/spec/twitter/relationship_spec.rb
@@ -3,22 +3,22 @@ require 'helper'
 describe Twitter::Relationship do
 
   describe "#source" do
-    it "should return a User when source is set" do
+    it "returns a User when source is set" do
       source = Twitter::Relationship.new('source' => {}).source
       source.should be_a Twitter::User
     end
-    it "should return nil when source is not set" do
+    it "returns nil when source is not set" do
       source = Twitter::Relationship.new.source
       source.should be_nil
     end
   end
 
   describe "#target" do
-    it "should return a User when target is set" do
+    it "returns a User when target is set" do
       target = Twitter::Relationship.new('target' => {}).target
       target.should be_a Twitter::User
     end
-    it "should return nil when target is not set" do
+    it "returns nil when target is not set" do
       target = Twitter::Relationship.new.target
       target.should be_nil
     end

--- a/spec/twitter/reply_spec.rb
+++ b/spec/twitter/reply_spec.rb
@@ -3,36 +3,36 @@ require 'helper'
 describe Twitter::Reply do
 
   describe "#sources" do
-    it "should return a collection of users who replied to a user" do
+    it "returns a collection of users who replied to a user" do
       sources = Twitter::Reply.new('sources' => [{}]).sources
       sources.should be_an Array
       sources.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       sources = Twitter::Reply.new.sources
       sources.should be_empty
     end
   end
 
   describe "#target_objects" do
-    it "should return a collection of statuses that reply to a user" do
+    it "returns a collection of statuses that reply to a user" do
       targets = Twitter::Reply.new('target_objects' => [{}]).target_objects
       targets.should be_an Array
       targets.first.should be_a Twitter::Status
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::Reply.new.target_objects
       targets.should be_empty
     end
   end
 
   describe "#targets" do
-    it "should return a collection that contains the replied-to status" do
+    it "returns a collection that contains the replied-to status" do
       targets = Twitter::Reply.new('targets' => [{}]).targets
       targets.should be_an Array
       targets.first.should be_a Twitter::Status
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::Reply.new.targets
       targets.should be_empty
     end

--- a/spec/twitter/retweet_spec.rb
+++ b/spec/twitter/retweet_spec.rb
@@ -3,36 +3,36 @@ require 'helper'
 describe Twitter::Retweet do
 
   describe "#sources" do
-    it "should return a collection of users who retweeted a user" do
+    it "returns a collection of users who retweeted a user" do
       sources = Twitter::Retweet.new('sources' => [{}]).sources
       sources.should be_an Array
       sources.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       sources = Twitter::Retweet.new.sources
       sources.should be_empty
     end
   end
 
   describe "#target_objects" do
-    it "should return a collection of retweets" do
+    it "returns a collection of retweets" do
       targets = Twitter::Retweet.new('target_objects' => [{}]).target_objects
       targets.should be_an Array
       targets.first.should be_a Twitter::Status
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::Retweet.new.target_objects
       targets.should be_empty
     end
   end
 
   describe "#targets" do
-    it "should return a collection containing the retweeted user" do
+    it "returns a collection containing the retweeted user" do
       targets = Twitter::Retweet.new('targets' => [{}]).targets
       targets.should be_an Array
       targets.first.should be_a Twitter::User
     end
-    it "should be empty when not set" do
+    it "is empty when not set" do
       targets = Twitter::Retweet.new.targets
       targets.should be_empty
     end

--- a/spec/twitter/saved_search_spec.rb
+++ b/spec/twitter/saved_search_spec.rb
@@ -3,17 +3,17 @@ require 'helper'
 describe Twitter::SavedSearch do
 
   describe "#==" do
-    it "should return true when ids and classes are equal" do
+    it "returns true when ids and classes are equal" do
       saved_search = Twitter::SavedSearch.new('id' => 1)
       other = Twitter::SavedSearch.new('id' => 1)
       (saved_search == other).should be_true
     end
-    it "should return false when classes are not equal" do
+    it "returns false when classes are not equal" do
       saved_search = Twitter::SavedSearch.new('id' => 1)
       other = Twitter::User.new('id' => 1)
       (saved_search == other).should be_false
     end
-    it "should return false when ids are not equal" do
+    it "returns false when ids are not equal" do
       saved_search = Twitter::SavedSearch.new('id' => 1)
       other = Twitter::SavedSearch.new('id' => 2)
       (saved_search == other).should be_false
@@ -21,11 +21,11 @@ describe Twitter::SavedSearch do
   end
 
   describe "#created_at" do
-    it "should return a Time when created_at is set" do
+    it "returns a Time when created_at is set" do
       saved_search = Twitter::SavedSearch.new('created_at' => "Mon Jul 16 12:59:01 +0000 2007")
       saved_search.created_at.should be_a Time
     end
-    it "should return nil when created_at is not set" do
+    it "returns nil when created_at is not set" do
       saved_search = Twitter::SavedSearch.new
       saved_search.created_at.should be_nil
     end

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -3,12 +3,12 @@ require 'helper'
 describe Twitter::SearchResults do
 
   describe "#results" do
-    it "should contain twitter status objects" do
+    it "contains twitter status objects" do
       search_results = Twitter::SearchResults.new('results' => [{'text' => 'tweet!'}])
       search_results.results.should be_a Array
       search_results.results.first.should be_a Twitter::Status
     end
-    it "should be an empty array if no search results passed" do
+    it "is an empty array if no search results passed" do
       search_results = Twitter::SearchResults.new
       search_results.results.should be_a Array
       search_results.results.should == []

--- a/spec/twitter/settings_spec.rb
+++ b/spec/twitter/settings_spec.rb
@@ -3,11 +3,11 @@ require 'helper'
 describe Twitter::Settings do
 
   describe "#trend_location" do
-    it "should return a Twitter::Place when set" do
+    it "returns a Twitter::Place when set" do
       place = Twitter::Settings.new('trend_location' => [{'countryCode' => 'US', 'name' => 'San Francisco', 'country' => 'United States', 'placeType' => {'name' => 'Town', 'code' => 7}, 'woeid' => 2487956, 'parentid' => 23424977, 'url' => 'http://where.yahooapis.com/v1/place/2487956'}])
       place.trend_location.should be_a Twitter::Place
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       place = Twitter::Settings.new
       place.trend_location.should be_nil
     end

--- a/spec/twitter/size_spec.rb
+++ b/spec/twitter/size_spec.rb
@@ -3,12 +3,12 @@ require 'helper'
 describe Twitter::Size do
 
   describe "#==" do
-    it "should return true when height and width are equal" do
+    it "returns true when height and width are equal" do
       size = Twitter::Size.new('h' => 1, 'w' => 1)
       other = Twitter::Size.new('h' => 1, 'w' => 1)
       (size == other).should be_true
     end
-    it "should return false when height and width are not equal" do
+    it "returns false when height and width are not equal" do
       size = Twitter::Size.new('h' => 1, 'w' => 1)
       other = Twitter::Size.new('h' => 1, 'w' => 2)
       (size == other).should be_false

--- a/spec/twitter/status_spec.rb
+++ b/spec/twitter/status_spec.rb
@@ -12,17 +12,17 @@ describe Twitter::Status do
   end
 
   describe "#==" do
-    it "should return true when ids and classes are equal" do
+    it "returns true when ids and classes are equal" do
       status = Twitter::Status.new('id' => 1)
       other = Twitter::Status.new('id' => 1)
       (status == other).should be_true
     end
-    it "should return false when classes are not equal" do
+    it "returns false when classes are not equal" do
       status = Twitter::Status.new('id' => 1)
       other = Twitter::User.new('id' => 1)
       (status == other).should be_false
     end
-    it "should return false when ids are not equal" do
+    it "returns false when ids are not equal" do
       status = Twitter::Status.new('id' => 1)
       other = Twitter::Status.new('id' => 2)
       (status == other).should be_false
@@ -30,68 +30,68 @@ describe Twitter::Status do
   end
 
   describe "#created_at" do
-    it "should return a Time when set" do
+    it "returns a Time when set" do
       status = Twitter::Status.new('created_at' => "Mon Jul 16 12:59:01 +0000 2007")
       status.created_at.should be_a Time
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       status = Twitter::Status.new
       status.created_at.should be_nil
     end
   end
 
   describe "#from_user" do
-    it "should return a screen name when from_user is set" do
+    it "returns a screen name when from_user is set" do
       status = Twitter::Status.new('from_user' => 'sferik')
       status.from_user.should be_a String
       status.from_user.should == "sferik"
     end
-    it "should return a screen name when screen_name is set" do
+    it "returns a screen name when screen_name is set" do
       status = Twitter::Status.new('user' => {'screen_name' => 'sferik'})
       status.from_user.should be_a String
       status.from_user.should == "sferik"
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       status = Twitter::Status.new
       status.from_user.should be_nil
     end
   end
 
   describe "#full_text" do
-    it "should return the text of a status" do
+    it "returns the text of a status" do
       status = Twitter::Status.new('text' => 'BOOSH')
       status.full_text.should be_a String
       status.full_text.should == "BOOSH"
     end
-    it "should return the text of a status without a user" do
+    it "returns the text of a status without a user" do
       status = Twitter::Status.new('text' => 'BOOSH', 'retweeted_status' => {'text' => 'BOOSH'})
       status.full_text.should be_a String
       status.full_text.should == "BOOSH"
     end
-    it "should return the full text of a retweeted status" do
+    it "returns the full text of a retweeted status" do
       status = Twitter::Status.new('retweeted_status' => {'text' => 'BOOSH', 'user' => {'screen_name' => 'sferik'}})
       status.full_text.should be_a String
       status.full_text.should == "RT @sferik: BOOSH"
     end
-    it "should return nil when retweeted_status is not set" do
+    it "returns nil when retweeted_status is not set" do
       status = Twitter::Status.new
       status.full_text.should be_nil
     end
   end
 
   describe "#geo" do
-    it "should return a Twitter::Point when set" do
+    it "returns a Twitter::Point when set" do
       status = Twitter::Status.new('geo' => {'type' => 'Point'})
       status.geo.should be_a Twitter::Point
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       status = Twitter::Status.new
       status.geo.should be_nil
     end
   end
 
   describe "#hashtags" do
-    it "should return an Array of Entity::Hashtag when entities are set" do
+    it "returns an Array of Entity::Hashtag when entities are set" do
       hashtags_hash = [{'text' => 'twitter',
           'indices' => [10, 33]}]
       hashtags = Twitter::Status.new('entities' => {'hashtags' => hashtags_hash}).hashtags
@@ -100,38 +100,38 @@ describe Twitter::Status do
       hashtags.first.indices.should == [10, 33]
       hashtags.first.text.should == 'twitter'
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       hashtags = Twitter::Status.new.hashtags
       hashtags.should be_nil
     end
-    it "should warn when not set" do
+    it "warns when not set" do
       Twitter::Status.new.hashtags
       $stderr.string.should =~ /To get hashtags, you must pass `:include_entities => true` when requesting the Twitter::Status\./
     end
   end
 
   describe "#media" do
-    it "should return media" do
+    it "returns media" do
       media = Twitter::Status.new('entities' => {'media' => [{'type' => 'photo'}]}).media
       media.should be_an Array
       media.first.should be_a Twitter::Photo
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       media = Twitter::Status.new.media
       media.should be_nil
     end
-    it "should warn when not set" do
+    it "warns when not set" do
       Twitter::Status.new.media
       $stderr.string.should =~ /To get media, you must pass `:include_entities => true` when requesting the Twitter::Status\./
     end
   end
 
   describe "#metadata" do
-    it "should return a User when user is set" do
+    it "returns a User when user is set" do
       metadata = Twitter::Status.new('metadata' => {}).metadata
       metadata.should be_a Twitter::Metadata
     end
-    it "should return nil when user is not set" do
+    it "returns nil when user is not set" do
       metadata = Twitter::Status.new.metadata
       metadata.should be_nil
     end
@@ -143,17 +143,17 @@ describe Twitter::Status do
         to_return(:body => fixture("oembed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
       @status = Twitter::Status.new('id' => 25938088801)
     end
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       @status.oembed
       a_get("/1/statuses/oembed.json?id=25938088801").
         should have_been_made
     end
-    it "should return an OEmbed instance" do
+    it "returns an OEmbed instance" do
       oembed = @status.oembed
       oembed.should be_a Twitter::OEmbed
     end
     context "without an id" do
-      it "should return nil" do
+      it "returns nil" do
         status = Twitter::Status.new
         status.oembed.should be_nil
       end
@@ -161,50 +161,50 @@ describe Twitter::Status do
   end
 
   describe "#place" do
-    it "should return a Twitter::Place when set" do
+    it "returns a Twitter::Place when set" do
       status = Twitter::Status.new('place' => {})
       status.place.should be_a Twitter::Place
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       status = Twitter::Status.new
       status.place.should be_nil
     end
   end
 
   describe "#retweeters_count" do
-    it "should return the count of favoriters when retweet_count is set" do
+    it "returns the count of favoriters when retweet_count is set" do
       status = Twitter::Status.new('retweet_count' => '1')
       status.retweeters_count.should be_a String
       status.retweeters_count.should == "1"
     end
-    it "should return the count of favoriters when retweeters_count is set" do
+    it "returns the count of favoriters when retweeters_count is set" do
       status = Twitter::Status.new('retweeters_count' => '1')
       status.retweeters_count.should be_a String
       status.retweeters_count.should == "1"
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       status = Twitter::Status.new
       status.retweeters_count.should be_nil
     end
   end
 
   describe "#retweeted_status" do
-    it "should return a Status when retweeted_status is set" do
+    it "returns a Status when retweeted_status is set" do
       status = Twitter::Status.new('retweeted_status' => {'text' => 'BOOSH'})
       status.retweeted_status.should be_a Twitter::Status
     end
-    it "should return nil when retweeted_status is not set" do
+    it "returns nil when retweeted_status is not set" do
       status = Twitter::Status.new
       status.retweeted_status.should be_nil
     end
-    it "should have text when retweeted_status is set" do
+    it "has text when retweeted_status is set" do
       status = Twitter::Status.new('retweeted_status' => {'text' => 'BOOSH'})
       status.retweeted_status.text.should == 'BOOSH'
     end
   end
 
   describe "#urls" do
-    it "should return an Array of Entity::Url when entities are set" do
+    it "returns an Array of Entity::Url when entities are set" do
       urls_hash = [{'url' => 'http://example.com/t.co',
           'expanded_url' => 'http://example.com/expanded',
           'display_url' => 'example.com/expanded',
@@ -215,26 +215,26 @@ describe Twitter::Status do
       urls.first.indices.should == [10, 33]
       urls.first.display_url.should == 'example.com/expanded'
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       urls = Twitter::Status.new.urls
       urls.should be_nil
     end
-    it "should warn when not set" do
+    it "warns when not set" do
       Twitter::Status.new.urls
       $stderr.string.should =~ /To get URLs, you must pass `:include_entities => true` when requesting the Twitter::Status\./
     end
   end
 
   describe "#user" do
-    it "should return a User when user is set" do
+    it "returns a User when user is set" do
       user = Twitter::Status.new('user' => {}).user
       user.should be_a Twitter::User
     end
-    it "should return nil when user is not set" do
+    it "returns nil when user is not set" do
       user = Twitter::Status.new.user
       user.should be_nil
     end
-    it "should have a status when status is set" do
+    it "has a status when status is set" do
       user = Twitter::Status.new('text' => 'Tweet text.', 'user' => {}).user
       user.status.should be_a Twitter::Status
       user.status.text.should == 'Tweet text.'
@@ -242,7 +242,7 @@ describe Twitter::Status do
   end
 
   describe "#user_mentions" do
-    it "should return an Array of Entity::User_Mention when entities are set" do
+    it "returns an Array of Entity::User_Mention when entities are set" do
       user_mentions_hash = [{'screen_name'=>'sferik',
           'name'=>'Erik Michaels-Ober',
           'id_str'=>'7505382',
@@ -254,11 +254,11 @@ describe Twitter::Status do
       user_mentions.first.indices.should == [0, 6]
       user_mentions.first.screen_name.should == 'sferik'
     end
-    it "should return nil when not set" do
+    it "returns nil when not set" do
       user_mentions = Twitter::Status.new.user_mentions
       user_mentions.should be_nil
     end
-    it "should warn when not set" do
+    it "warns when not set" do
       Twitter::Status.new.user_mentions
       $stderr.string.should =~ /To get user mentions, you must pass `:include_entities => true` when requesting the Twitter::Status\./
     end

--- a/spec/twitter/suggestion_spec.rb
+++ b/spec/twitter/suggestion_spec.rb
@@ -7,11 +7,11 @@ describe Twitter::Suggestion do
   end
 
   describe "#==" do
-    it "should return true when slugs are equal" do
+    it "returns true when slugs are equal" do
       other = Twitter::Suggestion.new('slug' => 'art-design')
       (@suggestion == other).should be_true
     end
-    it "should return false when coordinates are not equal" do
+    it "returns false when coordinates are not equal" do
       other = Twitter::Suggestion.new('slug' => 'design-art')
       (@suggestion == other).should be_false
     end

--- a/spec/twitter/trend_spec.rb
+++ b/spec/twitter/trend_spec.rb
@@ -7,11 +7,11 @@ describe Twitter::Trend do
   end
 
   describe "#==" do
-    it "should return true when names are equal" do
+    it "returns true when names are equal" do
       other = Twitter::Trend.new('name' => '#sevenwordsaftersex')
       (@trend == other).should be_true
     end
-    it "should return false when coordinates are not equal" do
+    it "returns false when coordinates are not equal" do
       other = Twitter::Trend.new('name' => '#sixwordsaftersex')
       (@trend == other).should be_false
     end

--- a/spec/twitter/user_spec.rb
+++ b/spec/twitter/user_spec.rb
@@ -3,17 +3,17 @@ require 'helper'
 describe Twitter::User do
 
   describe "#==" do
-    it "should return true when ids and classes are equal" do
+    it "returns true when ids and classes are equal" do
       user = Twitter::User.new('id' => 1)
       other = Twitter::User.new('id' => 1)
       (user == other).should be_true
     end
-    it "should return false when classes are not equal" do
+    it "returns false when classes are not equal" do
       user = Twitter::User.new('id' => 1)
       other = Twitter::Status.new('id' => 1)
       (user == other).should be_false
     end
-    it "should return false when ids are not equal" do
+    it "returns false when ids are not equal" do
       user = Twitter::User.new('id' => 1)
       other = Twitter::User.new('id' => 2)
       (user == other).should be_false
@@ -21,26 +21,26 @@ describe Twitter::User do
   end
 
   describe "#created_at" do
-    it "should return a Time when created_at is set" do
+    it "returns a Time when created_at is set" do
       user = Twitter::User.new('created_at' => "Mon Jul 16 12:59:01 +0000 2007")
       user.created_at.should be_a Time
     end
-    it "should return nil when created_at is not set" do
+    it "returns nil when created_at is not set" do
       user = Twitter::User.new
       user.created_at.should be_nil
     end
   end
 
   describe "#status" do
-    it "should return a Status when status is set" do
+    it "returns a Status when status is set" do
       status = Twitter::User.new('status' => {}).status
       status.should be_a Twitter::Status
     end
-    it "should return nil when status is not set" do
+    it "returns nil when status is not set" do
       status = Twitter::User.new.status
       status.should be_nil
     end
-    it "should have a user when user is set" do
+    it "includes a User when user is set" do
       status = Twitter::User.new('screen_name' => 'sferik', 'status' => {}).status
       status.user.should be_a Twitter::User
       status.user.screen_name.should == 'sferik'

--- a/spec/twitter_spec.rb
+++ b/spec/twitter_spec.rb
@@ -13,66 +13,66 @@ describe Twitter do
         to_return(:body => fixture("statuses.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
 
-    it "should request the correct resource" do
+    it "requests the correct resource" do
       Twitter.user_timeline('sferik')
       a_get("/1/statuses/user_timeline.json").
         with(:query => {:screen_name => "sferik"}).
         should have_been_made
     end
 
-    it "should return the same results as a client" do
+    it "returns the same results as a client" do
       Twitter.user_timeline('sferik').should == Twitter::Client.new.user_timeline('sferik')
     end
 
   end
 
   describe '.respond_to?' do
-    it "should take an optional argument" do
+    it "takes an optional argument" do
       Twitter.respond_to?(:new, true).should be_true
     end
   end
 
   describe ".new" do
-    it "should return a Twitter::Client" do
+    it "returns a Twitter::Client" do
       Twitter.new.should be_a Twitter::Client
     end
   end
 
   describe ".endpoint" do
-    it "should return the default endpoint" do
+    it "returns the default endpoint" do
       Twitter.endpoint.should == Twitter::Config::DEFAULT_ENDPOINT
     end
   end
 
   describe ".endpoint=" do
-    it "should set the endpoint" do
+    it "sets the endpoint" do
       Twitter.endpoint = 'http://tumblr.com/'
       Twitter.endpoint.should == 'http://tumblr.com/'
     end
   end
 
   describe ".user_agent" do
-    it "should return the default user agent" do
+    it "returns the default user agent" do
       Twitter.user_agent.should == Twitter::Config::DEFAULT_USER_AGENT
     end
   end
 
   describe ".user_agent=" do
-    it "should set the user_agent" do
+    it "sets the user_agent" do
       Twitter.user_agent = 'Custom User Agent'
       Twitter.user_agent.should == 'Custom User Agent'
     end
   end
 
   describe '.middleware' do
-    it "should return a Faraday::Builder" do
+    it "returns a Faraday::Builder" do
       Twitter.middleware.should be_kind_of(Faraday::Builder)
     end
   end
 
   describe ".configure" do
     Twitter::Config::VALID_OPTIONS_KEYS.each do |key|
-      it "should set the #{key}" do
+      it "sets the #{key}" do
         Twitter.configure do |config|
           config.send("#{key}=", key)
           Twitter.send(key).should == key


### PR DESCRIPTION
While writing tests for the Faraday builder change, I noticed that the test expectations were not consistent, some used `it "should request ..."` while others used `it "requests ..."`.  The latter syntax is more succinct and I think better articulates the expectation so I've changed the entire suite to use that style.
