### PR TITLE
Use method_defined? instead of responds_to?

### DIFF
--- a/lib/twitter/core_ext/string.rb
+++ b/lib/twitter/core_ext/string.rb
@@ -5,6 +5,6 @@ class String
   # @return [String]
   def camelize
     self.gsub(/\/(.?)/){"::#{$1.upcase}"}.gsub(/(?:^|_)(.)/){$1.upcase}
-  end unless respond_to?(:camelize)
+  end unless method_defined?(:camelize)
 
 end


### PR DESCRIPTION
The string extension for "camelize" checks if this method has already been defined by called responds_to?. This, however, doesn't work because it's being called on the String class rather than an instance of the String class (and hence, will always return false).

This means that if String#camelize is already defined, it will always be overridden. One notable situation where this breaks things is when you call something like 'some_string'.camelize(:lower) since the ActiveSupport version of camelize can accept an optional argument whereas the one defined in the Twitter gem cannot.
