### PR TITLE
Don't attempt to parse bodies that only contain spaces.

### DIFF
--- a/lib/twitter/response/parse_json.rb
+++ b/lib/twitter/response/parse_json.rb
@@ -7,7 +7,7 @@ module Twitter
 
       def parse(body)
         case body
-        when '', nil
+        when /\A^\s*$\z/, nil
           nil
         when 'true'
           true


### PR DESCRIPTION
Rails 2.x head responses return a single space as the body. This is due to a Safari bug where the headers
are not passed if the content length is zero.
