### PR TITLE
threaded_map prevents to catch errors properly

### DIFF
--- a/lib/twitter/core_ext/enumerable.rb
+++ b/lib/twitter/core_ext/enumerable.rb
@@ -1,12 +1,13 @@
 module Enumerable
 
   def threaded_map
+    initial_abort_on_exception = Thread.abort_on_exception
+    Thread.abort_on_exception ||= true
     threads = []
-    Thread.abort_on_exception = true
     each do |object|
-      threads << Thread.new{yield object}
+      threads << Thread.new { yield object }
     end
-    Thread.abort_on_exception = false
+    Thread.abort_on_exception = initial_abort_on_exception
     threads.map(&:value)
   end
 


### PR DESCRIPTION
Hi, suffering from this issue since update to 4.\* version. In my code I have somethinglike this:

``` ruby
users = twitter_request do
  client.users(sites.map(&:username))
end
```

and

``` ruby
def twitter_request(attempt = 1, &block)
  yield
rescue ::Twitter::Error::TooManyRequests => e
 ...
end
```

Before it worked just fine, but now, if any error appear in client.users(sites.map(&:username)) it is being handled by the `twitter_request` method but also raise up and cause the whole process to die.

Writing something like this each time I need to call the API:

``` ruby
users = begin
    client.users(sites.map(&:username))
  rescue ...
  rescue ....
  rescue ...
end
```

is not too good.

This problem could be solved by adding `Thread.abort_on_exception = true` to the threaded_map (and I think that would be correct to stop other threads if one fails)

Thank you,
Alex
