### PR TITLE
Correct endpoint of report_spam API

### DIFF
--- a/lib/twitter/api/spam_reporting.rb
+++ b/lib/twitter/api/spam_reporting.rb
@@ -22,7 +22,7 @@ module Twitter
       #   @param users [Array<Integer, String, Twitter::User>, Set<Integer, String, Twitter::User>] An array of Twitter user IDs, screen names, or objects.
       #   @param options [Hash] A customizable set of options.
       def report_spam(*args)
-        threaded_users_from_response(:post, "/1.1/report_spam.json", args)
+        threaded_users_from_response(:post, "/1.1/users/report_spam.json", args)
       end
 
     end

--- a/spec/twitter/api/spam_reporting_spec.rb
+++ b/spec/twitter/api/spam_reporting_spec.rb
@@ -8,11 +8,11 @@ describe Twitter::API::SpamReporting do
 
   describe "#report_spam" do
     before do
-      stub_post("/1.1/report_spam.json").with(:body => {:screen_name => "sferik"}).to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+      stub_post("/1.1/users/report_spam.json").with(:body => {:screen_name => "sferik"}).to_return(:body => fixture("sferik.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
     it "requests the correct resource" do
       @client.report_spam("sferik")
-      expect(a_post("/1.1/report_spam.json").with(:body => {:screen_name => "sferik"})).to have_been_made
+      expect(a_post("/1.1/users/report_spam.json").with(:body => {:screen_name => "sferik"})).to have_been_made
     end
     it "returns an array of users" do
       users = @client.report_spam("sferik")


### PR DESCRIPTION
/1.1/report_spam.json -> /1.1/users/report_spam.json

cf. https://dev.twitter.com/docs/api/1.1/post/report_spam
