### PR TITLE
Implemented no_retweets/ids for API 1.1 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ version 3 are no longer available in version 4:
 * `Twitter::API#disable_notifications`
 * `Twitter::API#enable_notifications`
 * `Twitter::API#end_session`
-* `Twitter::API#no_retweet_ids`
 * `Twitter::API#rate_limit_status`
 * `Twitter::API#rate_limited?`
 * `Twitter::API#recommendations`
@@ -318,6 +317,13 @@ Twitter.friends("gem")
 Twitter.friends(213747670)
 Twitter.friends
 ```
+
+**Fetch a collection of user_ids that the currently authenticated user does not want to receive retweets from**
+
+```ruby
+Twitter.no_retweet_ids
+````
+
 **Fetch the timeline of Tweets by a user**
 
 ```ruby

--- a/lib/twitter/api/friends_and_followers.rb
+++ b/lib/twitter/api/friends_and_followers.rb
@@ -315,6 +315,22 @@ module Twitter
       end
       alias following friends
 
+      # Returns a collection of user_ids that the currently authenticated user does not want to receive retweets from.
+      # =>
+      # @see https://dev.twitter.com/docs/api/1.1/get/friendships/no_retweets/ids
+      # @rate_limited Yes
+      # @authentication Requires user context
+      # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
+      # @return [Array<Integer>]
+      # @param options [Hash] A customizable set of options.
+      # @option options [Boolean] :stringify_ids Many programming environments will not consume our ids due to their size. Provide this option to have ids returned as strings instead. Read more about Twitter IDs, JSON and Snowflake.
+      # @example Enable rewteets and devise notifications for @sferik
+      #   Twitter.no_retweet_ids
+      def no_retweet_ids(options={})
+        get("/1.1/friendships/no_retweets/ids.json", options)[:body].map(&:to_i)
+      end
+      alias no_retweets_ids no_retweet_ids
+      
     end
   end
 end

--- a/spec/twitter/api/friends_and_followers_spec.rb
+++ b/spec/twitter/api/friends_and_followers_spec.rb
@@ -668,4 +668,23 @@ describe Twitter::API::FriendsAndFollowers do
     end
   end
 
+  describe "#no_retweet_ids" do
+    before do
+      stub_get("/1.1/friendships/no_retweets/ids.json").to_return(:body => fixture("ids.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+    end
+    it "requests the correct resource" do
+      @client.no_retweet_ids
+      expect(a_get("/1.1/friendships/no_retweets/ids.json")).to have_been_made
+    end
+    it "requests the correct resource when the alias is called" do
+      @client.no_retweets_ids
+      expect(a_get("/1.1/friendships/no_retweets/ids.json")).to have_been_made
+    end
+    it "returns users ids of those that do not wish to be retweeted" do
+      no_retweet_ids = @client.no_retweet_ids
+      expect(no_retweet_ids).to be_an Array
+      expect(no_retweet_ids.first).to be_an Integer
+      expect(no_retweet_ids.first).to eq 47
+    end
+  end
 end


### PR DESCRIPTION
Implemented changes for no_retweets/id as per request on Twitter gem mailing list. 
