### PR TITLE
Allow the oembed endpoints to take a url as well as a status id

### DIFF
--- a/lib/twitter/api/tweets.rb
+++ b/lib/twitter/api/tweets.rb
@@ -224,7 +224,8 @@ module Twitter
       # @example Return oEmbeds for Tweet with the ID 25938088801
       #   Twitter.status_with_activity(25938088801)
       def oembed(id, options={})
-        object_from_response(Twitter::OEmbed, :get, "/1.1/statuses/oembed.json?id=#{id}", options)
+        lookup = ( id.kind_of?(String) and id =~ /^https?:\/\//i ) ? "url" : "id"
+        object_from_response(Twitter::OEmbed, :get, "/1.1/statuses/oembed.json?#{lookup}=#{id}", options)
       end
 
       # Returns oEmbeds for Tweets
@@ -251,7 +252,7 @@ module Twitter
       def oembeds(*args)
         arguments = Twitter::API::Arguments.new(args)
         arguments.flatten.threaded_map do |id|
-          object_from_response(Twitter::OEmbed, :get, "/1.1/statuses/oembed.json?id=#{id}", arguments.options)
+          oembed(id, arguments.options)
         end
       end
 

--- a/spec/twitter/api/tweets_spec.rb
+++ b/spec/twitter/api/tweets_spec.rb
@@ -220,10 +220,15 @@ describe Twitter::API::Tweets do
   describe "#oembed" do
     before do
       stub_get("/1.1/statuses/oembed.json").with(:query => {:id => "25938088801"}).to_return(:body => fixture("oembed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+      stub_get("/1.1/statuses/oembed.json").with(:query => {:url => "https://twitter.com/sferik/status/25938088801"}).to_return(:body => fixture("oembed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
     it "requests the correct resource" do
       @client.oembed(25938088801)
       expect(a_get("/1.1/statuses/oembed.json").with(:query => {:id => "25938088801"})).to have_been_made
+    end
+    it "requests the correct resource when a url is given" do
+      @client.oembed("https://twitter.com/sferik/status/25938088801")
+      expect(a_get("/1.1/statuses/oembed.json").with(:query => {:url => "https://twitter.com/sferik/status/25938088801"}))
     end
     it "returns an array of OEmbed instances" do
       oembed = @client.oembed(25938088801)
@@ -234,10 +239,15 @@ describe Twitter::API::Tweets do
   describe "#oembeds" do
     before do
       stub_get("/1.1/statuses/oembed.json").with(:query => {:id => "25938088801"}).to_return(:body => fixture("oembed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
+      stub_get("/1.1/statuses/oembed.json").with(:query => {:url => "https://twitter.com/sferik/status/25938088801"}).to_return(:body => fixture("oembed.json"), :headers => {:content_type => "application/json; charset=utf-8"})
     end
     it "requests the correct resource" do
       @client.oembeds(25938088801)
       expect(a_get("/1.1/statuses/oembed.json").with(:query => {:id => "25938088801"})).to have_been_made
+    end
+    it "requests the correct resource when a url is given" do
+      @client.oembeds("https://twitter.com/sferik/status/25938088801")
+      expect(a_get("/1.1/statuses/oembed.json").with(:query => {:url => "https://twitter.com/sferik/status/25938088801"})).to have_been_made
     end
     it "returns an array of OEmbed instances" do
       oembeds = @client.oembeds(25938088801)


### PR DESCRIPTION
I've run into a situation where it would be nice to be able to pass a url to the oembed methods.

``` ruby
Twitter.oembed('https://twitter.com/bshelton229/status/294601034834255872')
```
