### PR TITLE
properly designate gemspec file encoding

### DIFF
--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+# encoding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'twitter/version'
@@ -8,10 +8,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'simple_oauth', '~> 0.2'
   spec.add_development_dependency 'bundler', '~> 1.0'
-  spec.authors = ["John Nunemaker", "Wynn Netherland", "Erik Michaels-Ober", "Steve Richert"]
+  spec.authors = ["John Nunemaker", "Wynn Netherland", "Erik Michaels-Ober", "Steve Richert", "Steve Agalloco"]
   spec.cert_chain  = ['certs/sferik.pem']
   spec.description = %q{A Ruby interface to the Twitter API.}
-  spec.email = ['nunemaker@gmail.com', 'wynn.netherland@gmail.com', 'sferik@gmail.com', 'steve.richert@gmail.com']
+  spec.email = ['nunemaker@gmail.com', 'wynn.netherland@gmail.com', 'sferik@gmail.com', 'steve.richert@gmail.com', 'steve.agalloco@gmail.com']
   spec.files = %w(.yardopts CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md Rakefile twitter.gemspec)
   spec.files += Dir.glob("lib/**/*.rb")
   spec.files += Dir.glob("spec/**/*")


### PR DESCRIPTION
I noticed this line in the gemspec which appeared to have been accidentally changed:

``` ruby
# coding: utf-8
```

This reverts it to:

``` ruby
# encoding: utf-8
```

While I was at it, I added myself to the gemspec :sunglasses: 
