### PR TITLE
convert nested classes in Twitter::Base#attrs

### DIFF
--- a/lib/twitter/base.rb
+++ b/lib/twitter/base.rb
@@ -94,7 +94,11 @@ module Twitter
     # @return [Hash]
     def attrs
       @attrs.inject({}) do |attrs, (key, value)|
-        attrs.merge!(key => respond_to?(key) ? send(key) : value)
+        if value.respond_to?(:attrs)
+          attrs.merge!(key => value.attrs)
+        else
+          attrs.merge!(key => respond_to?(key) ? send(key) : value)
+        end
       end
     end
     alias to_hash attrs

--- a/spec/twitter/base_spec.rb
+++ b/spec/twitter/base_spec.rb
@@ -108,4 +108,15 @@ describe Twitter::Base do
     end
   end
 
+  describe '#attrs' do
+    it 'returns a hash of attributes' do
+      expect(Twitter::Base.new(:id => 1).attrs).to eq({:id => 1})
+    end
+
+    it 'converts nested classes' do
+      base = Twitter::Base.new(:id => 2, :user => Twitter::User.new(:id => 4))
+      expect(base.attrs).to eq({ :id => 2, :user => { :id => 4}})
+    end
+  end
+
 end


### PR DESCRIPTION
Changes made for #361 resulted in nested classes not being converted to a hash, this calls checks for nested objects when invoking `Twitter::Base#attrs`
