### PR TITLE
Add Twitter::SearchResults methods for handling next results

### DIFF
--- a/lib/twitter/search_results.rb
+++ b/lib/twitter/search_results.rb
@@ -53,5 +53,15 @@ module Twitter
     end
     alias next_page? next_results?
 
+    # Returns a Hash of query parameters for the next result in the search
+    #
+    # Returned Hash can be merged into the previous search options list
+    # to easily access the next page
+    #
+    # @return [Hash]
+    def next_results
+      Faraday::Utils.parse_nested_query(@attrs[:search_metadata][:next_results][1..-1]).inject({}) { |memo, (k,v)| memo[k.to_sym] = v; memo} if next_results?
+    end
+    alias next_page next_results
   end
 end

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -111,5 +111,20 @@ describe Twitter::SearchResults do
       expect(next_results).to be_false
     end
   end
+  
+  describe "#next_results" do
+    let(:next_results) {Twitter::SearchResults.new(:search_metadata => 
+        {:next_results => "?max_id=249279667666817023&q=%23freebandnames&count=4&include_entities=1&result_type=mixed"
+      }).next_results
+    }
+
+    it "returns a hash of query parameters" do
+      expect(next_results).to be_a Hash
+    end
+    
+    it "returns a max_id" do
+      expect(next_results[:max_id]).to eq "249279667666817023"
+    end
+  end
 
 end


### PR DESCRIPTION
Twitter API v1.1 pages the search results. The information for the next page of search results is contained in the search_metadata field as a query string for the URL. This makes it difficult to use with the Twitter gem, which stores the query parameters as an options hash.

Added 2 methods to Twitter::SearchResults: next_results? and next_results

next_results? returns true if next_results if defined, false otherwise

next_results returns a hash of query parameters that can be merged into the original search options hash. Using the new hash then returns the next page of results.

Example usage:

``` ruby
search_results = twitter.search(query, opts)
while search_results.next_page? 
  opts.merge! search_results.next_page
  search_results = twitter.search(query, opts)
end
```

For backwards compatibility with v1 API, aliased next_results? to next_page? and next_results to next_page
