### PR TITLE
Added method Twitter::SearchResults#next_results?

### DIFF
--- a/lib/twitter/search_results.rb
+++ b/lib/twitter/search_results.rb
@@ -46,6 +46,12 @@ module Twitter
     def since_id
       @attrs[:search_metadata][:since_id] if search_metadata?
     end
+    
+    # @return [Boolean]
+    def next_results?
+      !@attrs[:search_metadata][:next_results].nil? if search_metadata?
+    end
+    alias next_page? next_results?
 
   end
 end

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -96,5 +96,20 @@ describe Twitter::SearchResults do
       expect(since_id).to be_nil
     end
   end
+  
+  describe "#next_results?" do
+    it "returns true when next_results is set" do
+      next_results = Twitter::SearchResults.new(:search_metadata => {:next_results => "?"}).next_results?
+      expect(next_results).to be_true
+    end
+    it "returns false when next_results is not set" do
+      next_results = Twitter::SearchResults.new(:search_metadata => {}).next_results?
+      expect(next_results).to be_false
+    end
+    it "returns false is search_metadata is not set" do
+      next_results = Twitter::SearchResults.new().next_results?
+      expect(next_results).to be_false
+    end
+  end
 
 end


### PR DESCRIPTION
Returns true if there is a next page for a Twitter SearchResult.
Returns false otherwise

Aliased to next_page? for backward compatibility with v1 API
