### PR TITLE
Implement oauth2/invalidate_token

### DIFF
--- a/lib/twitter/api/oauth.rb
+++ b/lib/twitter/api/oauth.rb
@@ -1,0 +1,24 @@
+require 'twitter/api/utils'
+require 'twitter/token'
+
+module Twitter
+  module API
+    module OAuth
+      include Twitter::API::Utils
+
+      # Allows a registered application to revoke an issued OAuth 2 Bearer Token by presenting its client credentials.
+      #
+      # @see https://dev.twitter.com/docs/api/1.1/post/oauth2/invalidate_token
+      # @rate_limited No
+      # @authentication Required
+      # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
+      # @param access_token [String] The value of the bearer token to revoke.
+      # @return [Twitter::Token] The invalidated token. token_type should be nil.
+      # @example Revoke a token
+      #   Twitter.invalidate_token("AAAA%2FAAA%3DAAAAAAAA")
+      def invalidate_token(access_token)
+        object_from_response(Twitter::Token, :post, "/oauth2/invalidate_token", :access_token => access_token)
+      end
+    end
+  end
+end

--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -5,6 +5,7 @@ require 'twitter/api/favorites'
 require 'twitter/api/friends_and_followers'
 require 'twitter/api/help'
 require 'twitter/api/lists'
+require 'twitter/api/oauth'
 require 'twitter/api/places_and_geo'
 require 'twitter/api/saved_searches'
 require 'twitter/api/search'
@@ -32,6 +33,7 @@ module Twitter
     include Twitter::API::FriendsAndFollowers
     include Twitter::API::Help
     include Twitter::API::Lists
+    include Twitter::API::OAuth
     include Twitter::API::PlacesAndGeo
     include Twitter::API::SavedSearches
     include Twitter::API::Search

--- a/lib/twitter/token.rb
+++ b/lib/twitter/token.rb
@@ -1,0 +1,7 @@
+require 'twitter/base'
+
+module Twitter
+  class Token < Twitter::Base
+    attr_reader :token_type, :access_token
+  end
+end

--- a/spec/twitter/api/oauth_spec.rb
+++ b/spec/twitter/api/oauth_spec.rb
@@ -1,0 +1,23 @@
+require 'helper'
+
+describe Twitter::API::OAuth do
+
+  before do
+    @client = Twitter::Client.new
+  end
+
+  describe "#invalidate_token" do
+    before do
+      stub_post("/oauth2/invalidate_token").with(:body => {:access_token => "AAAA%2FAAA%3DAAAAAAAA"}).to_return(:body => '{"access_token" : "AAAA%2FAAA%3DAAAAAAAA"}', :headers => {:content_type => "application/json; charset=utf-8"})
+    end
+    it "requests the correct resource" do
+      @client.invalidate_token("AAAA%2FAAA%3DAAAAAAAA")
+      expect(a_post("/oauth2/invalidate_token").with(:body => {:access_token => "AAAA%2FAAA%3DAAAAAAAA"})).to have_been_made
+    end
+    it "returns the invalidated token" do
+      token = @client.invalidate_token("AAAA%2FAAA%3DAAAAAAAA")
+      expect(token.access_token).to eq "AAAA%2FAAA%3DAAAAAAAA"
+      expect(token.token_type).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
Here's my first attempt on implementing [POST oauth2/invalidate_token](https://dev.twitter.com/docs/api/1.1/post/oauth2/invalidate_token). I'm pretty sure I missed a few things from your lecture last Sunday, but I think I got most of them right.

When I implemented `Twitter::Token`, I wasn't really sure where to inherit from, so I settled with `Twitter::Base`. To be honest, I'm really just winging the whole thing, so let me know which parts need improvement.

Lastly, I apologize for being a few days late with the pull request. I've been swamped with work all week and I was really only able to dedicate time for this just now.

Cheers!
