### PR TITLE
Please expose id_str, in_reply_to_id_str etc

### DIFF
--- a/lib/twitter/entity.rb
+++ b/lib/twitter/entity.rb
@@ -3,5 +3,10 @@ require 'twitter/base'
 module Twitter
   class Entity < Twitter::Base
     attr_reader :indices
+
+    # @return [String]
+    def id_str
+      @attrs[:id_str]
+    end
   end
 end

--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -135,6 +135,21 @@ module Twitter
       !@attrs[:user].nil?
     end
 
+    # @return [String]
+    def id_str
+      @attrs[:id_str]
+    end
+
+    # @return [String]
+    def in_reply_to_status_id_str
+      @attrs[:in_reply_to_status_id_str]
+    end
+
+    # @return [String]
+    def in_reply_to_user_id_str
+      @attrs[:in_reply_to_user_id_str]
+    end
+
   private
 
     # @param klass [Class]

--- a/lib/twitter/user.rb
+++ b/lib/twitter/user.rb
@@ -96,6 +96,11 @@ module Twitter
       !@attrs[:status].nil?
     end
 
+    # @return [String]
+    def id_str
+      @attrs[:id_str]
+    end
+
   private
 
     def insecure_url(url)

--- a/spec/twitter/entity_spec.rb
+++ b/spec/twitter/entity_spec.rb
@@ -1,0 +1,16 @@
+require 'helper'
+
+describe Twitter::Entity do
+
+  describe "#id_str" do
+    it "returns the id_str of the Entity when set" do
+      entity = Twitter::Entity.new(:id => 7505382, :id_str => '7505382')
+      expect(entity.id_str).to eq('7505382')
+    end
+    it "returns nil when not set" do
+      entity = Twitter::Entity.new(:id => 7505382)
+      expect(entity.id_str).to be_nil
+    end
+  end
+
+end

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -338,4 +338,37 @@ describe Twitter::Tweet do
     end
   end
 
+  describe "#id_str" do
+    it "returns the id_str of the Tweet when set" do
+      tweet = Twitter::Tweet.new(:id => 28669546014, :id_str => '28669546014')
+      expect(tweet.id_str).to eq('28669546014')
+    end
+    it "returns nil when not set" do
+      tweet = Twitter::Tweet.new(:id => 28669546014)
+      expect(tweet.id_str).to be_nil
+    end
+  end
+
+  describe "#in_reply_to_status_id_str" do
+    it "returns the in_reply_to_status_id_str of the Tweet when set" do
+      tweet = Twitter::Tweet.new(:id => 28669546014, :in_reply_to_status_id_str => '222221331344')
+      expect(tweet.in_reply_to_status_id_str).to eq('222221331344')
+    end
+    it "returns nil when not set" do
+      tweet = Twitter::Tweet.new(:id => 28669546014)
+      expect(tweet.in_reply_to_status_id_str).to be_nil
+    end
+  end
+
+  describe "#in_reply_to_user_id_str" do
+    it "returns the in_reply_to_user_id_str of the Tweet when set" do
+      tweet = Twitter::Tweet.new(:id => 28669546014, :in_reply_to_user_id_str => '1133234561')
+      expect(tweet.in_reply_to_user_id_str).to eq('1133234561')
+    end
+    it "returns nil when not set" do
+      tweet = Twitter::Tweet.new(:id => 28669546014)
+      expect(tweet.in_reply_to_user_id_str).to be_nil
+    end
+  end
+
 end

--- a/spec/twitter/user_spec.rb
+++ b/spec/twitter/user_spec.rb
@@ -258,4 +258,15 @@ describe Twitter::User do
     end
   end
 
+  describe "#id_str" do
+    it "returns the id_str of the User when set" do
+      user = Twitter::User.new(:id => 7505382, :id_str => '7505382')
+      expect(user.id_str).to eq('7505382')
+    end
+    it "returns nil when not set" do
+      user = Twitter::User.new(:id => 7505382)
+      expect(user.id_str).to be_nil
+    end
+  end
+
 end


### PR DESCRIPTION
Twitter IDs are now so large that most API clients - this one included - are failing to handle them properly as numbers. Twitter have thus provided a string version for each, with names ending in _str.

Try it - grab any recent tweet. Compare `tweet.id` with `tweet.attrs[:id_str]` -- they are different numbers.

We now need to use these _str versions to successfully reply to and retweet statuses, otherwise we are trying to reply to a different status (or one that might not exist -- this could be the root cause of #362).

Could you please expose the _str attributes out so that they are public and we can see them in the docs? (Unless there is a clever way of supporting very large numbers in the existing Integer `id`, `in_reply_to_id` etc. values. I am new to Ruby, so I may have missed something.)
