### PR TITLE
Faraday connection defaults: Verify TLS peer by default.

### DIFF
--- a/lib/twitter/default.rb
+++ b/lib/twitter/default.rb
@@ -21,7 +21,7 @@ module Twitter
         :timeout => 10,
       },
       :ssl => {
-        :verify => false
+        :verify => true
       },
     } unless defined? Twitter::Default::CONNECTION_OPTIONS
     IDENTITY_MAP = false unless defined? Twitter::Default::IDENTITY_MAP


### PR DESCRIPTION
There is no reason to disable peer verification by default.
It's a failure on Twitter's part if 'api.twitter.com' doesn't carry a valid SSL/TLS certificate.
