### PR TITLE
Added Twitter::SearchResults#refresh_url

### DIFF
--- a/lib/twitter/search_results.rb
+++ b/lib/twitter/search_results.rb
@@ -63,5 +63,16 @@ module Twitter
       Faraday::Utils.parse_nested_query(@attrs[:search_metadata][:next_results][1..-1]).inject({}) { |memo, (k,v)| memo[k.to_sym] = v; memo} if next_results?
     end
     alias next_page next_results
+    
+    # Returns a Hash of query parameters for the refresh url in the search
+    #
+    # Returned Hash can be merged into the previous search options list
+    # to easily access the refresh page
+    #
+    # @return [Hash]
+    def refresh_url
+      Faraday::Utils.parse_nested_query(@attrs[:search_metadata][:refresh_url][1..-1]).inject({}) { |memo, (k,v)| memo[k.to_sym] = v; memo}
+    end
+    alias refresh_page refresh_url
   end
 end

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -127,4 +127,19 @@ describe Twitter::SearchResults do
     end
   end
 
+  describe "#refresh_url" do
+    let(:refresh_url) {Twitter::SearchResults.new(:search_metadata =>
+        {:refresh_url => "?since_id=249279667666817023&q=%23freebandnames&count=4&include_entities=1&result_type=recent"
+      }).refresh_url
+    }
+
+    it "returns a hash of query parameters" do
+      expect(refresh_url).to be_a Hash
+    end
+
+    it "returns a since_id" do
+      expect(refresh_url[:since_id]).to eq "249279667666817023"
+    end
+  end
+
 end


### PR DESCRIPTION
Implemented missing method (refresh_url) for Twitter::SearchResults.
