### PR TITLE
Handle error codes in Twitter::ClientError

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -3,7 +3,7 @@ require 'twitter/rate_limit'
 module Twitter
   # Custom error class for rescuing from all Twitter errors
   class Error < StandardError
-    attr_reader :rate_limit, :wrapped_exception
+    attr_reader :rate_limit, :wrapped_exception, :code
 
     # @return [Hash]
     def self.errors
@@ -19,15 +19,34 @@ module Twitter
     #
     # @param exception [Exception, String]
     # @param response_headers [Hash]
+    # @param code [Integer]
     # @return [Twitter::Error]
-    def initialize(exception=$!, response_headers={})
+    def initialize(exception=$!, response_headers={}, code = nil)
       @rate_limit = Twitter::RateLimit.new(response_headers)
       @wrapped_exception = exception
+      @code = code
       exception.respond_to?(:backtrace) ? super(exception.message) : super(exception.to_s)
     end
 
     def backtrace
       @wrapped_exception.respond_to?(:backtrace) ? @wrapped_exception.backtrace : super
+    end
+
+    private
+
+    def self.parse_error(body)
+      if body.nil?
+        ['', nil]
+      elsif body[:error]
+        [body[:error], nil]
+      elsif body[:errors]
+        first = Array(body[:errors]).first
+        if first.is_a?(Hash)
+          [first[:message].chomp, first[:code]]
+        else
+          [first.chomp, nil]
+        end
+      end
     end
 
   end

--- a/lib/twitter/error/client_error.rb
+++ b/lib/twitter/error/client_error.rb
@@ -10,26 +10,9 @@ module Twitter
       # @param response [Hash]
       # @return [Twitter::Error]
       def self.from_response(response={})
-        new(parse_error(response[:body]), response[:response_headers])
+        error, code = parse_error(response[:body])
+        new(error, response[:response_headers], code)
       end
-
-    private
-
-      def self.parse_error(body)
-        if body.nil?
-          ''
-        elsif body[:error]
-          body[:error]
-        elsif body[:errors]
-          first = Array(body[:errors]).first
-          if first.is_a?(Hash)
-            first[:message].chomp
-          else
-            first.chomp
-          end
-        end
-      end
-
     end
   end
 end

--- a/lib/twitter/error/server_error.rb
+++ b/lib/twitter/error/server_error.rb
@@ -11,7 +11,8 @@ module Twitter
       # @param response [Hash]
       # @return [Twitter::Error]
       def self.from_response(response={})
-        new(nil, response[:response_headers])
+        _, code = parse_error(response[:body])
+        new(nil, response[:response_headers], code)
       end
 
       # Initializes a new ServerError object
@@ -19,8 +20,8 @@ module Twitter
       # @param message [String]
       # @param response_headers [Hash]
       # @return [Twitter::Error::ServerError]
-      def initialize(message=nil, response_headers={})
-        super((message || self.class.const_get(:MESSAGE)), response_headers)
+      def initialize(message=nil, response_headers={}, code = nil)
+        super((message || self.class.const_get(:MESSAGE)), response_headers, code)
       end
 
     end

--- a/spec/twitter/error/client_error_spec.rb
+++ b/spec/twitter/error/client_error_spec.rb
@@ -18,6 +18,33 @@ describe Twitter::Error::ClientError do
         end
       end
     end
+    context "when HTTP status is #{status} and body is errors" do
+      context "when errors is an array of hashes" do
+        context "when error code is nil" do
+          before do
+            body_message = '{"errors":[{"message":"Client Error"}]}'
+            stub_get("/1.1/statuses/user_timeline.json").with(:query => {:screen_name => "sferik"}).to_return(:status => status, :body => body_message)
+          end
+          it "raises #{exception.name}" do
+            expect{@client.user_timeline("sferik")}.to raise_error { |error|
+              expect(error.code).to eq nil
+            }
+          end
+
+          context "when error code is 187" do
+            before do
+              body_message = '{"errors":[{"message":"Client Error","code": 187 }]}'
+              stub_get("/1.1/statuses/user_timeline.json").with(:query => {:screen_name => "sferik"}).to_return(:status => status, :body => body_message)
+            end
+            it "raises #{exception.name}" do
+              expect{@client.user_timeline("sferik")}.to raise_error { |error|
+                expect(error.code).to eq 187
+              }
+            end
+          end
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Receiving a lot of different errors in an application, We started to look at errors code in twitter errors.
https://dev.twitter.com/docs/error-codes-responses

It seems logical to us to add them to the `Twitter::ClientError` class and handle them in our code.

That way instead of parsing the error message, we can compare error_codes in our code.

First PR here so don't hesitate to criticise my code and the way I handled that one.
