### PR TITLE
Remove NullObject#!

### DIFF
--- a/lib/twitter/null_object.rb
+++ b/lib/twitter/null_object.rb
@@ -10,9 +10,5 @@ module Twitter
     end
     alias nil? null?
 
-    def !
-      true
-    end
-
   end
 end

--- a/spec/twitter/null_object_spec.rb
+++ b/spec/twitter/null_object_spec.rb
@@ -9,11 +9,4 @@ describe Twitter::NullObject do
     end
   end
 
-  describe "#!" do
-    it "returns true" do
-      null_object = Twitter::NullObject.new
-      expect(!null_object).to be_true
-    end
-  end
-
 end


### PR DESCRIPTION
#415 added a `NullObject` class that defines `!`. There are multiple problems with this:
- It breaks Ruby 1.8 compatibility, where `!` wasn't a method. It's not even syntactically allowed, so you'll get a strange error like:

```
/dependencies.rb:251:in `require': twitter/lib/twitter/null_object.rb:13: syntax error, unexpected '!' (SyntaxError)
twitter/lib/twitter/null_object.rb:18: syntax error, unexpected kEND, expecting $end
```
- It's inconsistent. You can't create a falsy object of your own in Ruby. So, even if `if !NullObject.new` would work, `unless NullObject.new` would not. The ability to overwrite `!` is IMO only useful for DSLs.
- It's not used or tested anywhere, except for a synthetic spec that just mirrors the implementation.

So, I propose to remove it.
