### PR TITLE
Twitter::Error.errors lists descendants recursively

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -17,7 +17,8 @@ module Twitter
     # @return [Hash]
     def self.errors
       @errors ||= descendants.each_with_object({}) do |klass, hash|
-        hash[klass::HTTP_STATUS_CODE] = klass
+        hash[klass::HTTP_STATUS_CODE] = klass if defined?(klass::HTTP_STATUS_CODE)
+        hash.update(klass.errors)
       end
     end
 

--- a/spec/twitter/error_spec.rb
+++ b/spec/twitter/error_spec.rb
@@ -17,4 +17,10 @@ describe Twitter::Error do
     end
   end
 
+  describe "#errors" do
+    it "lists descendant errors" do
+      expect(Twitter::Error.errors).to have_key(403)
+    end
+  end
+
 end


### PR DESCRIPTION
While <del>stealing</del> borrowing the improved client/server exception handling approach for Octokit.rb, I noticed that `Twitter::Error.errors` throws an exception:

```
>> Twitter::Error.errors
NameError: uninitialized constant Twitter::Error::ClientError::HTTP_STATUS_CODE
        from /Users/wynn/.coral/repos/twitter@sferik/lib/twitter/error.rb:20:in `block in errors'
        from /Users/wynn/.coral/repos/twitter@sferik/lib/twitter/error.rb:19:in `each'
...
```

This change makes that method a bit more defensive and allows child error types to be listed recursively.
