### PR TITLE
Encode urls before parsing for unicode issues

### DIFF
--- a/lib/twitter/user.rb
+++ b/lib/twitter/user.rb
@@ -40,7 +40,7 @@ module Twitter
     # @param size [String, Symbol] The size of the image. Must be one of: 'mobile', 'mobile_retina', 'web', 'web_retina', 'ipad', or 'ipad_retina'
     # @return [String]
     def profile_banner_uri(size=:web)
-      ::URI.parse(insecure_uri([@attrs[:profile_banner_url], size].join('/'))) if @attrs[:profile_banner_url]
+      parse_encoded_uri(insecure_uri([@attrs[:profile_banner_url], size].join('/'))) if @attrs[:profile_banner_url]
     end
     alias profile_banner_url profile_banner_uri
 
@@ -49,7 +49,7 @@ module Twitter
     # @param size [String, Symbol] The size of the image. Must be one of: 'mobile', 'mobile_retina', 'web', 'web_retina', 'ipad', or 'ipad_retina'
     # @return [String]
     def profile_banner_uri_https(size=:web)
-      ::URI.parse([@attrs[:profile_banner_url], size].join('/')) if @attrs[:profile_banner_url]
+      parse_encoded_uri([@attrs[:profile_banner_url], size].join('/')) if @attrs[:profile_banner_url]
     end
     alias profile_banner_url_https profile_banner_uri_https
 
@@ -65,7 +65,7 @@ module Twitter
     # @param size [String, Symbol] The size of the image. Must be one of: 'mini', 'normal', 'bigger' or 'original'
     # @return [String]
     def profile_image_uri(size=:normal)
-      ::URI.parse(insecure_uri(profile_image_uri_https(size))) if @attrs[:profile_image_url_https]
+      parse_encoded_uri(insecure_uri(profile_image_uri_https(size))) if @attrs[:profile_image_url_https]
     end
     alias profile_image_url profile_image_uri
 
@@ -80,7 +80,7 @@ module Twitter
       # https://a0.twimg.com/profile_images/1759857427/image1326743606.png
       # https://a0.twimg.com/profile_images/1759857427/image1326743606_mini.png
       # https://a0.twimg.com/profile_images/1759857427/image1326743606_bigger.png
-      ::URI.parse(@attrs[:profile_image_url_https].sub(PROFILE_IMAGE_SUFFIX_REGEX, profile_image_suffix(size))) if @attrs[:profile_image_url_https]
+      parse_encoded_uri(@attrs[:profile_image_url_https].sub(PROFILE_IMAGE_SUFFIX_REGEX, profile_image_suffix(size))) if @attrs[:profile_image_url_https]
     end
     alias profile_image_url_https profile_image_uri_https
 
@@ -107,6 +107,10 @@ module Twitter
     end
 
   private
+
+    def parse_encoded_uri(uri)
+      ::URI.parse(::URI.encode(uri))
+    end
 
     def insecure_uri(uri)
       uri.to_s.sub(/^https/i, 'http')

--- a/spec/twitter/user_spec.rb
+++ b/spec/twitter/user_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 require 'helper'
 
 describe Twitter::User do
@@ -65,6 +66,10 @@ describe Twitter::User do
   end
 
   describe "#profile_banner_uri" do
+    it "accepts utf8 urls" do
+      user = Twitter::User.new(:id => 7505382, :profile_banner_url => "https://si0.twimg.com/profile_banners/7505382/1348266581©_normal.png")
+      expect(user.profile_banner_uri).to be_a URI
+    end
     it "returns a URI when profile_banner_url is set" do
       user = Twitter::User.new(:id => 7505382, :profile_banner_url => "https://si0.twimg.com/profile_banners/7505382/1348266581")
       expect(user.profile_banner_uri).to be_a URI
@@ -110,6 +115,10 @@ describe Twitter::User do
   end
 
   describe "#profile_banner_uri_https" do
+    it "accepts utf8 urls" do
+      user = Twitter::User.new(:id => 7505382, :profile_banner_url => "https://si0.twimg.com/profile_banners/7505382/1348266581©_normal.png")
+      expect(user.profile_banner_uri_https).to be_a URI
+    end
     it "returns a URI when profile_banner_url is set" do
       user = Twitter::User.new(:id => 7505382, :profile_banner_url => "https://si0.twimg.com/profile_banners/7505382/1348266581")
       expect(user.profile_banner_uri_https).to be_a URI
@@ -166,6 +175,10 @@ describe Twitter::User do
   end
 
   describe "#profile_image_uri" do
+    it "accepts utf8 urls" do
+      user = Twitter::User.new(:id => 7505382, :profile_image_url_https => "https://si0.twimg.com/profile_images/7505382/1348266581©_normal.png")
+      expect(user.profile_image_uri).to be_a URI
+    end
     it "returns a URI when profile_image_url_https is set" do
       user = Twitter::User.new(:id => 7505382, :profile_image_url_https => "https://a0.twimg.com/profile_images/1759857427/image1326743606_normal.png")
       expect(user.profile_image_uri).to be_a URI
@@ -207,6 +220,10 @@ describe Twitter::User do
   end
 
   describe "#profile_image_uri_https" do
+    it "accepts utf8 urls" do
+      user = Twitter::User.new(:id => 7505382, :profile_image_url_https => "https://si0.twimg.com/profile_images/7505382/1348266581©_normal.png")
+      expect(user.profile_image_uri_https).to be_a URI
+    end
     it "returns a URI when profile_image_url_https is set" do
       user = Twitter::User.new(:id => 7505382, :profile_image_url_https => "https://a0.twimg.com/profile_images/1759857427/image1326743606_normal.png")
       expect(user.profile_image_uri_https).to be_a URI


### PR DESCRIPTION
Twitter keeps unicode characters in urls. And some URI.parse throws BadURI when using them

Example was with profile_image_url
https://si0.twimg.com/profile_images/75824278/©SWhite_57230012_normal.JPG
