### PR TITLE
Fix behavior of Twitter::Tweet.entities? method.

### DIFF
--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -27,7 +27,9 @@ module Twitter
 
     # @return [Boolean]
     def entities?
-      !@attrs[:entities].nil?
+      return false if @attrs[:entities].nil?
+
+      @attrs[:entities].any? { |k, v| !v.empty? }
     end
 
     def filter_level

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -57,6 +57,12 @@ describe Twitter::Tweet do
       expect(tweet.entities?).to be_false
     end
 
+    it "returns false if there are blank lists of entities set" do
+      urls_array = []
+      tweet = Twitter::Tweet.new(:id => 28669546014, :entities => {:urls => urls_array})
+      expect(tweet.entities?).to be_false
+    end
+
     it "returns true if there are entities set" do
       urls_array = [
         {


### PR DESCRIPTION
Previously, this method returned true when inflating a tweet that has no entities because the inflated model does not set `@attrs[:entities]` to `nil`, but to a hash of empty lists.

For example:

``` ruby
> tweet = Twitter.status(372706156361576448)
=> #<Twitter::Tweet:0x000000062add38
 @attrs=
  {:created_at=>"Wed Aug 28 13:04:06 +0000 2013",
   :id=>372706156361576448,
   # snip extras for brevity
   :entities=>{:hashtags=>[], :symbols=>[], :urls=>[], :user_mentions=>[]},
   :favorited=>false,
   :retweeted=>false,
   :lang=>"en"}
> tweet.entities?
=> true
```

This pull request fixes this behavior to properly return `false` in this case. It also adds a spec to test this behavior. I opted to change this method as it seems less likely to affect things than changing the inflating method to set to `nil`.
