### PR TITLE
Use POST method for #filter

### DIFF
--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -15,7 +15,7 @@ module Twitter
       end
 
       def filter(options={}, &block)
-        request(:get, 'https://stream.twitter.com:443/1.1/statuses/filter.json', options, &block)
+        request(:post, 'https://stream.twitter.com:443/1.1/statuses/filter.json', options, &block)
       end
 
       def firehose(options={}, &block)


### PR DESCRIPTION
[Twitter API](https://dev.twitter.com/docs/api/1.1) recommends to use POST method for statuses/filter.
https://dev.twitter.com/docs/api/1.1/post/statuses/filter
