### PR TITLE
Add :raw_data option to streaming client.

### DIFF
--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -7,6 +7,7 @@ require 'twitter/streaming/response'
 module Twitter
   module Streaming
     class Client < Twitter::Client
+      attr_accessor :raw_data
       attr_writer :connection
 
       def initialize(options={}, &block)
@@ -75,10 +76,15 @@ module Twitter
       end
 
       def item_factory(data)
-        if data[:id]
-          Tweet.new(data)
-        elsif data[:direct_message]
-          DirectMessage.new(data[:direct_message])
+        if @raw_data
+          data
+        else
+          json = JSON.parse(data, :symbolize_names => true)
+          if json[:id]
+            Tweet.new(json)
+          elsif json[:direct_message]
+            DirectMessage.new(json[:direct_message])
+          end
         end
       end
     end

--- a/lib/twitter/streaming/response.rb
+++ b/lib/twitter/streaming/response.rb
@@ -21,7 +21,7 @@ module Twitter
       def on_body(data)
         @tokenizer.extract(data).each do |line|
           next if line.empty?
-          @block.call(JSON.parse(line, :symbolize_names => true))
+          @block.call(line)
         end
       end
 

--- a/spec/twitter/streaming/client_spec.rb
+++ b/spec/twitter/streaming/client_spec.rb
@@ -61,6 +61,18 @@ describe Twitter::Streaming::Client do
     expect(tweets.first.text).to eq "The problem with your code is that it's doing exactly what you told it to do."
   end
 
+  it "#sample_raw" do
+    client = Twitter::Streaming::Client.new(:raw_data => true)
+    client.connection = FakeConnection.new(fixture("track_streaming.json"))
+    lines = []
+    client.sample do |line|
+      lines << line
+    end
+    expect(lines).to have(2).entries
+    expect(lines.first).to be_a String
+    expect(lines.first).to include "The problem with your code is that it's doing exactly what you told it to do."
+  end
+
   it "#site" do
     @client.connection = FakeConnection.new(fixture("track_streaming.json"))
     tweets = []


### PR DESCRIPTION
Added :raw_data option to streaming client. This allows code to do its own JSON parsing or skip parsing altogether.

While using the streaming client today I noticed that I would get "unexpected token" errors. I found that skipping the `JSON.parse` step within this code and using `Yajl::Encoder.encode` in my code handles the data coming back from Twitter. I suspect it has something to do with UTF-8 but did not investigate further.

`ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-linux]`

Thanks for a very useful gem!
