### PR TITLE
Twitter::Error::descendants fails if there is a comparable object in the object space.

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -12,7 +12,7 @@ module Twitter
 
     # @return [Array]
     def self.descendants
-      ObjectSpace.each_object(::Class).select{|klass| klass < self}
+      ObjectSpace.each_object(class << self; self; end).select{|klass| klass < self}
     end
 
     # Initializes a new Error object

--- a/spec/twitter/error_spec.rb
+++ b/spec/twitter/error_spec.rb
@@ -24,6 +24,10 @@ describe Twitter::Error do
       end
       expect(Twitter::Error.descendants).to include Twitter::Error::GatewayTimeout
     end
+
+    it "Does not include Twitter::Error in list of descendants" do
+      expect(Twitter::Error.descendants).to_not include Twitter::Error
+    end
   end
 
 end


### PR DESCRIPTION
This changes descendants to only find objects that descend from Twitter::Error
