### PR TITLE
Use Addressable::URI everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,8 +423,8 @@ These methods are aliased to `#url` for users who prefer that nomenclature.
 `Twitter::User` previously had a `#url` method, which returned the user's
 website. This URI is now available via the `#website` method.
 
-All `#uri` methods now return `URI` objects instead of strings. To convert a
-`URI` object to a string, call `#to_s` on it.
+All `#uri` methods now return `Addressable::URI` objects instead of strings. To convert an
+`Addressable::URI` object to a string, call `#to_s` on it.
 
 ## Configuration
 Twitter API v1.1 requires you to authenticate via OAuth, so you'll need to

--- a/lib/twitter/base.rb
+++ b/lib/twitter/base.rb
@@ -74,7 +74,7 @@ module Twitter
       # @param key2 [Symbol]
       def define_uri_method(key1, key2)
         define_method(key1) do ||
-          URI.parse(@attrs[key2]) if @attrs[key2]
+          Addressable::URI.parse(@attrs[key2]) if @attrs[key2]
         end
         memoize(key1)
       end

--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -62,7 +62,7 @@ module Twitter
     end
 
     def oauth_auth_header(method, uri, params={})
-      uri = URI.parse(uri)
+      uri = Addressable::URI.parse(uri)
       SimpleOAuth::Header.new(method, uri, params, credentials)
     end
 

--- a/lib/twitter/list.rb
+++ b/lib/twitter/list.rb
@@ -8,23 +8,23 @@ module Twitter
       :mode, :name, :slug, :subscriber_count
     object_attr_reader :User, :user
 
-    # @return [URI] The URI to the list members.
+    # @return [Addressable::URI] The URI to the list members.
     def members_uri
-      URI.parse("https://twitter.com/#{user.screen_name}/#{slug}/members")
+      Addressable::URI.parse("https://twitter.com/#{user.screen_name}/#{slug}/members")
     end
     memoize :members_uri
     alias members_url members_uri
 
-    # @return [URI] The URI to the list subscribers.
+    # @return [Addressable::URI] The URI to the list subscribers.
     def subscribers_uri
-      URI.parse("https://twitter.com/#{user.screen_name}/#{slug}/subscribers")
+      Addressable::URI.parse("https://twitter.com/#{user.screen_name}/#{slug}/subscribers")
     end
     memoize :subscribers_uri
     alias subscribers_url subscribers_uri
 
-    # @return [URI] The URI to the list.
+    # @return [Addressable::URI] The URI to the list.
     def uri
-      URI.parse("https://twitter.com/#{user.screen_name}/#{slug}")
+      Addressable::URI.parse("https://twitter.com/#{user.screen_name}/#{slug}")
     end
     memoize :uri
     alias url uri

--- a/lib/twitter/rest/api/users.rb
+++ b/lib/twitter/rest/api/users.rb
@@ -169,7 +169,7 @@ module Twitter
           user_id = case user
           when Integer
             user
-          when String, URI
+          when String, URI, Addressable::URI
             user(user).id
           when Twitter::User
             user.id

--- a/lib/twitter/rest/api/utils.rb
+++ b/lib/twitter/rest/api/utils.rb
@@ -185,7 +185,7 @@ module Twitter
             else
               set_compound_key("screen_name", user, hash, prefix)
             end
-          when URI
+          when URI, Addressable::URI
             set_compound_key("screen_name", user.path.split("/").last, hash, prefix)
           when Twitter::User
             set_compound_key("user_id", user.id, hash, prefix)

--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -79,7 +79,7 @@ module Twitter
 
     # @return [String] The URL to the tweet.
     def uri
-      URI.parse("https://twitter.com/#{user.screen_name}/status/#{id}")
+      Addressable::URI.parse("https://twitter.com/#{user.screen_name}/status/#{id}")
     end
     memoize :uri
     alias url uri

--- a/lib/twitter/user.rb
+++ b/lib/twitter/user.rb
@@ -109,14 +109,14 @@ module Twitter
 
     # @return [String] The URL to the user.
     def uri
-      URI.parse("https://twitter.com/#{screen_name}")
+      Addressable::URI.parse("https://twitter.com/#{screen_name}")
     end
     memoize :uri
     alias url uri
 
     # @return [String] The URL to the user's website.
     def website
-      URI.parse(@attrs[:url]) if @attrs[:url]
+      Addressable::URI.parse(@attrs[:url]) if @attrs[:url]
     end
     memoize :website
 
@@ -128,7 +128,7 @@ module Twitter
   private
 
     def parse_encoded_uri(uri)
-      URI.parse(URI.encode(uri))
+      Addressable::URI.parse(URI.encode(uri))
     end
 
     def insecure_uri(uri)

--- a/spec/twitter/entity/uri_spec.rb
+++ b/spec/twitter/entity/uri_spec.rb
@@ -29,7 +29,7 @@ describe Twitter::Entity::URI do
   describe "#expanded_uri" do
     it "returns a URI when the expanded_url is set" do
       uri = Twitter::Entity::URI.new(:expanded_url => "https://github.com/sferik")
-      expect(uri.expanded_uri).to be_a URI
+      expect(uri.expanded_uri).to be_a Addressable::URI
       expect(uri.expanded_uri.to_s).to eq("https://github.com/sferik")
     end
     it "returns nil when the expanded_url is not set" do
@@ -52,7 +52,7 @@ describe Twitter::Entity::URI do
   describe "#uri" do
     it "returns a URI when the url is set" do
       uri = Twitter::Entity::URI.new(:url => "https://github.com/sferik")
-      expect(uri.uri).to be_a URI
+      expect(uri.uri).to be_a Addressable::URI
       expect(uri.uri.to_s).to eq("https://github.com/sferik")
     end
     it "returns nil when the url is not set" do

--- a/spec/twitter/media/photo_spec.rb
+++ b/spec/twitter/media/photo_spec.rb
@@ -59,7 +59,7 @@ describe Twitter::Media::Photo do
   describe "#expanded_uri" do
     it "returns a URI when the expanded_url is set" do
       photo = Twitter::Media::Photo.new(:id => 1, :expanded_url => "http://pbs.twimg.com/media/BQD6MPOCEAAbCH0.png")
-      expect(photo.expanded_uri).to be_a URI
+      expect(photo.expanded_uri).to be_a Addressable::URI
       expect(photo.expanded_uri.to_s).to eq("http://pbs.twimg.com/media/BQD6MPOCEAAbCH0.png")
     end
     it "returns nil when the expanded_url is not set" do
@@ -82,7 +82,7 @@ describe Twitter::Media::Photo do
   describe "#media_uri" do
     it "returns a URI when the media_url is set" do
       photo = Twitter::Media::Photo.new(:id => 1, :media_url => "http://pbs.twimg.com/media/BQD6MPOCEAAbCH0.png")
-      expect(photo.media_uri).to be_a URI
+      expect(photo.media_uri).to be_a Addressable::URI
       expect(photo.media_uri.to_s).to eq("http://pbs.twimg.com/media/BQD6MPOCEAAbCH0.png")
     end
     it "returns nil when the media_url is not set" do
@@ -105,7 +105,7 @@ describe Twitter::Media::Photo do
   describe "#media_uri_https" do
     it "returns a URI when the media_url_https is set" do
       photo = Twitter::Media::Photo.new(:id => 1, :media_url_https => "http://pbs.twimg.com/media/BQD6MPOCEAAbCH0.png")
-      expect(photo.media_uri_https).to be_a URI
+      expect(photo.media_uri_https).to be_a Addressable::URI
       expect(photo.media_uri_https.to_s).to eq("http://pbs.twimg.com/media/BQD6MPOCEAAbCH0.png")
     end
     it "returns nil when the media_url_https is not set" do
@@ -128,7 +128,7 @@ describe Twitter::Media::Photo do
   describe "#uri" do
     it "returns a URI when the url is set" do
       photo = Twitter::Media::Photo.new(:id => 1, :url => "http://pbs.twimg.com/media/BQD6MPOCEAAbCH0.png")
-      expect(photo.uri).to be_a URI
+      expect(photo.uri).to be_a Addressable::URI
       expect(photo.uri.to_s).to eq("http://pbs.twimg.com/media/BQD6MPOCEAAbCH0.png")
     end
     it "returns nil when the url is not set" do

--- a/spec/twitter/oembed_spec.rb
+++ b/spec/twitter/oembed_spec.rb
@@ -5,7 +5,7 @@ describe Twitter::OEmbed do
   describe "#author_uri" do
     it "returns a URI when the author_url is set" do
       oembed = Twitter::OEmbed.new(:author_url => "https://twitter.com/sferik")
-      expect(oembed.author_uri).to be_a URI
+      expect(oembed.author_uri).to be_a Addressable::URI
       expect(oembed.author_uri.to_s).to eq("https://twitter.com/sferik")
     end
     it "returns nil when the author_uri is not set" do
@@ -87,7 +87,7 @@ describe Twitter::OEmbed do
   describe "#provider_uri" do
     it "returns a URI when the provider_url is set" do
       oembed = Twitter::OEmbed.new(:provider_url => "http://twitter.com")
-      expect(oembed.provider_uri).to be_a URI
+      expect(oembed.provider_uri).to be_a Addressable::URI
       expect(oembed.provider_uri.to_s).to eq("http://twitter.com")
     end
     it "returns nil when the provider_uri is not set" do
@@ -136,7 +136,7 @@ describe Twitter::OEmbed do
   describe "#uri" do
     it "returns a URI when the url is set" do
       oembed = Twitter::OEmbed.new(:url => "https://twitter.com/twitterapi/status/133640144317198338")
-      expect(oembed.uri).to be_a URI
+      expect(oembed.uri).to be_a Addressable::URI
       expect(oembed.uri.to_s).to eq("https://twitter.com/twitterapi/status/133640144317198338")
     end
     it "returns nil when the url is not set" do

--- a/spec/twitter/place_spec.rb
+++ b/spec/twitter/place_spec.rb
@@ -108,7 +108,7 @@ describe Twitter::Place do
   describe "#uri" do
     it "returns a URI when the url is set" do
       place = Twitter::Place.new(:woeid => "247f43d441defc03", :url => "https://api.twitter.com/1.1/geo/id/247f43d441defc03.json")
-      expect(place.uri).to be_a URI
+      expect(place.uri).to be_a Addressable::URI
       expect(place.uri.to_s).to eq("https://api.twitter.com/1.1/geo/id/247f43d441defc03.json")
     end
     it "returns nil when the url is not set" do

--- a/spec/twitter/trend_spec.rb
+++ b/spec/twitter/trend_spec.rb
@@ -28,7 +28,7 @@ describe Twitter::Trend do
   describe "#uri" do
     it "returns a URI when the url is set" do
       trend = Twitter::Trend.new(:url => "http://twitter.com/search/?q=%23sevenwordsaftersex")
-      expect(trend.uri).to be_a URI
+      expect(trend.uri).to be_a Addressable::URI
       expect(trend.uri.to_s).to eq("http://twitter.com/search/?q=%23sevenwordsaftersex")
     end
     it "returns nil when the url is not set" do

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -332,7 +332,7 @@ describe Twitter::Tweet do
   describe "#uri" do
     it "returns the URI to the tweet" do
       tweet = Twitter::Tweet.new(:id => 28669546014, :user => {:id => 7505382, :screen_name => "sferik"})
-      expect(tweet.uri).to be_a URI
+      expect(tweet.uri).to be_a Addressable::URI
       expect(tweet.uri.to_s).to eq("https://twitter.com/sferik/status/28669546014")
     end
   end

--- a/spec/twitter/user_spec.rb
+++ b/spec/twitter/user_spec.rb
@@ -68,11 +68,11 @@ describe Twitter::User do
   describe "#profile_banner_uri" do
     it "accepts utf8 urls" do
       user = Twitter::User.new(:id => 7505382, :profile_banner_url => "https://si0.twimg.com/profile_banners/7505382/1348266581©_normal.png")
-      expect(user.profile_banner_uri).to be_a URI
+      expect(user.profile_banner_uri).to be_a Addressable::URI
     end
     it "returns a URI when profile_banner_url is set" do
       user = Twitter::User.new(:id => 7505382, :profile_banner_url => "https://si0.twimg.com/profile_banners/7505382/1348266581")
-      expect(user.profile_banner_uri).to be_a URI
+      expect(user.profile_banner_uri).to be_a Addressable::URI
     end
     it "returns nil when profile_banner_uri is not set" do
       user = Twitter::User.new(:id => 7505382)
@@ -117,11 +117,11 @@ describe Twitter::User do
   describe "#profile_banner_uri_https" do
     it "accepts utf8 urls" do
       user = Twitter::User.new(:id => 7505382, :profile_banner_url => "https://si0.twimg.com/profile_banners/7505382/1348266581©_normal.png")
-      expect(user.profile_banner_uri_https).to be_a URI
+      expect(user.profile_banner_uri_https).to be_a Addressable::URI
     end
     it "returns a URI when profile_banner_url is set" do
       user = Twitter::User.new(:id => 7505382, :profile_banner_url => "https://si0.twimg.com/profile_banners/7505382/1348266581")
-      expect(user.profile_banner_uri_https).to be_a URI
+      expect(user.profile_banner_uri_https).to be_a Addressable::URI
     end
     it "returns nil when created_at is not set" do
       user = Twitter::User.new(:id => 7505382)
@@ -177,11 +177,11 @@ describe Twitter::User do
   describe "#profile_image_uri" do
     it "accepts utf8 urls" do
       user = Twitter::User.new(:id => 7505382, :profile_image_url_https => "https://si0.twimg.com/profile_images/7505382/1348266581©_normal.png")
-      expect(user.profile_image_uri).to be_a URI
+      expect(user.profile_image_uri).to be_a Addressable::URI
     end
     it "returns a URI when profile_image_url_https is set" do
       user = Twitter::User.new(:id => 7505382, :profile_image_url_https => "https://a0.twimg.com/profile_images/1759857427/image1326743606_normal.png")
-      expect(user.profile_image_uri).to be_a URI
+      expect(user.profile_image_uri).to be_a Addressable::URI
     end
     it "returns nil when created_at is not set" do
       user = Twitter::User.new(:id => 7505382)
@@ -222,11 +222,11 @@ describe Twitter::User do
   describe "#profile_image_uri_https" do
     it "accepts utf8 urls" do
       user = Twitter::User.new(:id => 7505382, :profile_image_url_https => "https://si0.twimg.com/profile_images/7505382/1348266581©_normal.png")
-      expect(user.profile_image_uri_https).to be_a URI
+      expect(user.profile_image_uri_https).to be_a Addressable::URI
     end
     it "returns a URI when profile_image_url_https is set" do
       user = Twitter::User.new(:id => 7505382, :profile_image_url_https => "https://a0.twimg.com/profile_images/1759857427/image1326743606_normal.png")
-      expect(user.profile_image_uri_https).to be_a URI
+      expect(user.profile_image_uri_https).to be_a Addressable::URI
     end
     it "returns nil when created_at is not set" do
       user = Twitter::User.new(:id => 7505382)
@@ -305,7 +305,7 @@ describe Twitter::User do
   describe "#uri" do
     it "returns the URI to the user" do
       user = Twitter::User.new(:id => 7505382, :screen_name => "sferik")
-      expect(user.uri).to be_a URI
+      expect(user.uri).to be_a Addressable::URI
       expect(user.uri.to_s).to eq("https://twitter.com/sferik")
     end
   end
@@ -313,7 +313,7 @@ describe Twitter::User do
   describe "#website" do
     it "returns a URI when the url is set" do
       user = Twitter::User.new(:id => 7505382, :url => "https://github.com/sferik")
-      expect(user.website).to be_a URI
+      expect(user.website).to be_a Addressable::URI
       expect(user.website.to_s).to eq("https://github.com/sferik")
     end
     it "returns nil when the url is not set" do


### PR DESCRIPTION
I prepared this branch before I opened issue https://github.com/sferik/twitter/issues/487

I opened an Issue rather than a PR because I felt it was likely to break compatibility.
But nevertheless it appears @sferik that we, in principle, want to use Addressable::URI instead.

So here is a commit that explicitly does so.
