### PR TITLE
Implement #marshal_load and #marshal_dump for Twitter::Identity

### DIFF
--- a/lib/twitter/identity.rb
+++ b/lib/twitter/identity.rb
@@ -15,5 +15,20 @@ module Twitter
       attrs.fetch(:id)
       super
     end
+
+    # Serializes an object
+    #
+    # @return [String]
+    def marshal_dump
+      to_hash
+    end
+
+    # Converts serialized data into an object
+    #
+    # @param attrs [Hash]
+    # @return [Twitter::Identity]
+    def marshal_load(attrs = {})
+      initialize(attrs)
+    end
   end
 end

--- a/spec/twitter/identifiable_spec.rb
+++ b/spec/twitter/identifiable_spec.rb
@@ -26,4 +26,11 @@ describe Twitter::Identity do
     end
   end
 
+  it 'can be serialized with Marshal' do
+    identity = Twitter::Tweet.new(:id => 1, :screen_name => 'sferik')
+    marshaled_identity = Marshal.dump(identity)
+    unmarshaled_identity = Marshal.load(marshaled_identity)
+    expect(identity == unmarshaled_identity).to be true
+  end
+
 end


### PR DESCRIPTION
In version 5.2.0 of the gem, marshaling tweets, users, and other objects that inherit from `Twitter::Identity` raises an exception, which makes certain things difficult, like storing them in `Rails.cache`. 

Here's a simple example to reproduce the exception:

``` ruby
require 'twitter'

client = Twitter::REST::Client.new do |config|
  config.consumer_key        = "YOUR_CONSUMER_KEY"
  config.consumer_secret     = "YOUR_CONSUMER_SECRET"
  config.access_token        = "YOUR_ACCESS_TOKEN"
  config.access_token_secret = "YOUR_ACCESS_SECRET"
end

tweet = client.user_timeline('gem').first
Marshal.dump(tweet)
# => TypeError: no _dump_data is defined for class Proc
```

This commit defines `marshal_dump` and `marshal_load` for the `Twitter::Identity` class. Unfortunately, the test I wrote doesn't fail without those methods because `rspec-mocks` redefines `Marshal.load`. So any feedback on how to write a better test (or on the pull request in general) would be appreciated.
