### PR TITLE
Introduce meaningful constant name

### DIFF
--- a/lib/twitter/rest/request/multipart_with_file.rb
+++ b/lib/twitter/rest/request/multipart_with_file.rb
@@ -5,6 +5,9 @@ module Twitter
     module Request
       class MultipartWithFile < Faraday::Middleware
         CONTENT_TYPE = 'Content-Type'
+        GIF_REGEX = /\.gif$/i
+        JPEG_REGEX = /\.jpe?g/i
+        PNG_REGEX = /\.png$/i
 
         def call(env)
           env[:body].each do |key, value|
@@ -19,11 +22,11 @@ module Twitter
 
         def mime_type(path)
           case path
-          when /\.jpe?g/i
-            'image/jpeg'
-          when /\.gif$/i
+          when GIF_REGEX
             'image/gif'
-          when /\.png$/i
+          when JPEG_REGEX
+            'image/jpeg'
+          when PNG_REGEX
             'image/png'
           else
             'application/octet-stream'

--- a/lib/twitter/rest/response/parse_json.rb
+++ b/lib/twitter/rest/response/parse_json.rb
@@ -5,9 +5,11 @@ module Twitter
   module REST
     module Response
       class ParseJson < Faraday::Response::Middleware
+        WHITESPACE_REGEX = /\A^\s*$\z/
+
         def parse(body)
           case body
-          when /\A^\s*$\z/, nil
+          when WHITESPACE_REGEX, nil
             nil
           else
             JSON.parse(body, :symbolize_names => true)


### PR DESCRIPTION
Replace raw regex with a named constant that conveys the intended
expression match.

Let me know how you feel about naming here. I was torn between `EMPTY_RESPONSE` or `WHITESPACE`.
