### PR TITLE
Explicitly state Site Streaming API has limited access

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ does not work on Ruby 2.0.0][bug].
 [tweetstream]: http://rubygems.org/gems/tweetstream
 [bug]: https://github.com/tweetstream/tweetstream/issues/117
 
+Site Streams are restricted to whitelisted accounts. To apply for access to
+Site Streams see the "Applying for access" section in the Site Streams Twitter
+API [here][twitter]. User Streams, however, are open and do not require approval.
+
+[twitter]: https://dev.twitter.com/docs/streaming-apis/streams/site#Applying_for_access
+
 Unlike the rest of this library, this feature is not well tested and not
 recommended for production applications. That said, if you need to do Twitter
 streaming on Ruby 2.0.0, this is probably your best option. I've decided to

--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -58,6 +58,7 @@ module Twitter
       # @see https://dev.twitter.com/docs/api/1.1/get/site
       # @see https://dev.twitter.com/docs/streaming-apis/streams/site
       # @see https://dev.twitter.com/docs/streaming-apis/parameters
+      # @note Site Streams is currently in a limited beta. Access is restricted to whitelisted accounts.
       # @param follow [Enumerable<Integer, String, Twitter::User>] A list of user IDs, indicating the users to return statuses for in the stream.
       # @param options [Hash] A customizable set of options.
       # @option options [String] :with Specifies whether to return information for just the users specified in the follow parameter, or include messages from accounts they follow.


### PR DESCRIPTION
Site Streaming API access is limited. This is not immediately clear in the documentation/comments of the gem, although it is clear in the twitter API. Adding a note similar to the firehose streaming API will help clear up any confusion that the developer is misusing the API through the gem. Also added restriction information to `README` for clarification.
