### PR TITLE
issue #512, favorite! does not return Twitter::Error::AlreadyFavorited e...

### DIFF
--- a/lib/twitter/error/already_favorited.rb
+++ b/lib/twitter/error/already_favorited.rb
@@ -4,7 +4,7 @@ module Twitter
   class Error
     # Raised when a Tweet has already been favorited
     class AlreadyFavorited < Twitter::Error::Forbidden
-      MESSAGE = 'You have already favorited this status'
+      MESSAGE = 'You have already favorited this status.'
     end
   end
 end

--- a/spec/fixtures/already_favorited.json
+++ b/spec/fixtures/already_favorited.json
@@ -1,1 +1,1 @@
-{"errors":[{"message":"You have already favorited this status","code":139}]}
+{"errors":[{"message":"You have already favorited this status.","code":139}]}


### PR DESCRIPTION
...ven the tweet is already favorited, becuase the message is missing a dot
