### PR TITLE
added Twitter::Entities#entity_types

### DIFF
--- a/lib/twitter/entities.rb
+++ b/lib/twitter/entities.rb
@@ -11,7 +11,7 @@ module Twitter
 
     # @return [Array<Symbol>]
     def entities
-      @attrs.fetch(:entities, {}).reject{ |_, value| value.empty? }.keys
+      @attrs.fetch(:entities, {}).reject { |_, value| value.empty? }.keys
     end
 
     # @return [Boolean]

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -60,8 +60,8 @@ describe Twitter::Tweet do
 
     it 'returns an array of entity types included with the tweet' do
       entities = {
-        :urls => [{ :url => 'http://example.com/t.co' }],
-        :media => [{ :url => 'http://example.com/t.co' }]
+        :urls => [{:url => 'http://example.com/t.co'}],
+        :media => [{:url => 'http://example.com/t.co'}]
       }
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.entities).to eq([:urls, :media])


### PR DESCRIPTION
A recent issue on TweetStream (tweetstream/tweetstream#157) made me realize that it's difficult to know which entities are included with a Tweet. You can of course check each type to see if they contain any data, but I thought it would useful to have a simple way of getting the types.

Twitter's docs have no term for what these are, so I chose to call them types. Here's the usage:

``` ruby
tweet.entity_types
# => [:urls, :symbols, :hashtags]
```

I toyed with the idea of also adding methods for each type as well (`#hashtags?`, `#uris?`, etc.) but those seem frivolous.
