### PR TITLE
converted all attr_reader's to public methods

### DIFF
--- a/lib/twitter/basic_user.rb
+++ b/lib/twitter/basic_user.rb
@@ -7,4 +7,13 @@ module Twitter
     alias_method :username, :screen_name
     alias_method :user_name, :screen_name
   end
+
+  def following
+  	@attrs.following
+  end
+
+  def screen_name
+  	@attrs.screen_name
+  end
+  
 end

--- a/lib/twitter/configuration.rb
+++ b/lib/twitter/configuration.rb
@@ -11,6 +11,26 @@ module Twitter
     # Returns an array of photo sizes
     #
     # @return [Array<Twitter::Size>]
+
+    def characters_reserved_per_media
+   @attrs.characters_reserved_per_media
+end
+def max_media_per_upload
+   @attrs.max_media_per_upload
+end
+def non_username_paths
+   @attrs.non_username_paths
+end
+def photo_size_limit
+   @attrs.photo_size_limit
+end
+def short_url_length
+   @attrs.short_url_length
+end
+def short_url_length_https
+   @attrs.short_url_length_https
+end
+
     def photo_sizes
       Array(@attrs[:photo_sizes]).inject({}) do |object, (key, value)|
         object[key] = Size.new(value)

--- a/lib/twitter/language.rb
+++ b/lib/twitter/language.rb
@@ -4,4 +4,15 @@ module Twitter
   class Language < Twitter::Base
     attr_reader :code, :name, :status
   end
+
+  def code
+   @attrs.code
+end
+def name
+   @attrs.name
+end
+def status
+   @attrs.status
+end
+
 end

--- a/lib/twitter/oembed.rb
+++ b/lib/twitter/oembed.rb
@@ -6,4 +6,30 @@ module Twitter
                 :type, :version, :width
     uri_attr_reader :author_uri, :provider_uri, :uri
   end
+
+  def author_name
+   @attrs.author_name
+end
+def cache_age
+   @attrs.cache_age
+end
+def height
+   @attrs.height
+end
+def html
+   @attrs.html
+end
+def provider_name
+   @attrs.provider_name
+end
+def type
+   @attrs.type
+end
+def version
+   @attrs.version
+end
+def width
+   @attrs.width
+end
+
 end

--- a/lib/twitter/settings.rb
+++ b/lib/twitter/settings.rb
@@ -7,4 +7,33 @@ module Twitter
                 :sleep_time, :time_zone
     object_attr_reader :Place, :trend_location
   end
+
+  def always_use_https
+   @attrs.always_use_https
+end
+def discoverable_by_email
+   @attrs.discoverable_by_email
+end
+def geo_enabled
+   @attrs.geo_enabled
+end
+def language
+   @attrs.language
+end
+def protected
+   @attrs.protected
+end
+def screen_name
+   @attrs.screen_name
+end
+def show_all_inline_media
+   @attrs.show_all_inline_media
+end
+def sleep_time
+   @attrs.sleep_time
+end
+def time_zone
+   @attrs.time_zone
+end
+
 end

--- a/lib/twitter/source_user.rb
+++ b/lib/twitter/source_user.rb
@@ -4,5 +4,14 @@ module Twitter
   class SourceUser < Twitter::BasicUser
     attr_reader :all_replies, :blocking, :can_dm, :followed_by, :marked_spam,
                 :notifications_enabled, :want_retweets
+
+    def attributes
+        @attrs
+    end
+
+    def attr
+        @attrs
+    end
+    
   end
 end

--- a/lib/twitter/suggestion.rb
+++ b/lib/twitter/suggestion.rb
@@ -7,6 +7,16 @@ module Twitter
     attr_reader :name, :size, :slug
 
     # @return [Array<Twitter::User>]
+
+    def attributes
+        @attrs
+    end
+
+    def attr
+        @attrs
+    end
+
+    
     def users
       Array(@attrs[:users]).collect do |user|
         User.new(user)

--- a/lib/twitter/target_user.rb
+++ b/lib/twitter/target_user.rb
@@ -4,4 +4,14 @@ module Twitter
   class TargetUser < Twitter::BasicUser
     attr_reader :followed_by
   end
+
+  def attributes
+        @attrs
+    end
+
+    def attr
+        @attrs
+    end
+
+    
 end

--- a/lib/twitter/token.rb
+++ b/lib/twitter/token.rb
@@ -8,6 +8,22 @@ module Twitter
     BEARER_TYPE = 'bearer'
 
     # @return [Boolean]
+
+    def attributes
+        @attrs
+    end
+
+    def attr
+        @attrs
+    end
+
+    def access_token
+   @attrs.access_token
+end
+def token_type
+   @attrs.token_type
+end
+    
     def bearer?
       @attrs[:token_type] == BEARER_TYPE
     end

--- a/lib/twitter/trend.rb
+++ b/lib/twitter/trend.rb
@@ -6,5 +6,15 @@ module Twitter
     include Equalizer.new(:name)
     attr_reader :events, :name, :promoted_content, :query
     uri_attr_reader :uri
+
+    def attributes
+        @attrs
+    end
+
+    def attr
+        @attrs
+    end
+
+    
   end
 end

--- a/lib/twitter/trend_results.rb
+++ b/lib/twitter/trend_results.rb
@@ -19,6 +19,16 @@ module Twitter
     #
     # @param attrs [Hash]
     # @return [Twitter::TrendResults]
+
+    def attributes
+        @attrs
+    end
+
+    def attr
+        @attrs
+    end
+
+    
     def initialize(attrs = {})
       @attrs = attrs
       @collection = Array(@attrs[:trends]).collect do |trend|

--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -27,6 +27,58 @@ module Twitter
 
     # @note May be > 140 characters.
     # @return [String]
+    def attributes
+        @attrs
+    end
+
+    def attr
+        @attrs
+    end
+    
+    def favorite_count
+        @attrs.favorite_count
+    end
+
+    def favorited
+        @attrs.favorited
+    end
+
+    def in_reply_to_screen_name
+        @attrs.in_reply_to_screen_name
+    end
+
+    def in_reply_to_attrs_id
+        @attrs.in_reply_to_attrs_id
+    end
+
+    def in_reply_to_status_id
+        @attrs.in_reply_to_status_id
+    end    
+
+    def in_reply_to_user_id
+        @attr.in_reply_to_user_id
+    end
+
+    def retweet_count
+        @attrs.retweet_count
+    end
+
+    def retweeted
+        @attrs.retweeted
+    end
+
+    def source
+        @attrs.source
+    end
+
+    def text
+        @attrs.text
+    end
+
+    def truncated
+        @attrs.truncated
+    end
+
     def full_text
       if retweet?
         prefix = text[/\A(RT @[a-z0-9_]{1,20}: )/i, 1]

--- a/lib/twitter/user.rb
+++ b/lib/twitter/user.rb
@@ -33,6 +33,97 @@ module Twitter
     alias_method :tweeted?, :status?
 
     # @return [Array<Twitter::Entity::URI>]
+    def connections
+   @attrs.connections
+end
+def contributors_enabled
+   @attrs.contributors_enabled
+end
+def default_profile
+   @attrs.default_profile
+end
+def default_profile_image
+   @attrs.default_profile_image
+end
+def description
+   @attrs.description
+end
+def favourites_count
+   @attrs.favourites_count
+end
+def follow_request_sent
+   @attrs.follow_request_sent
+end
+def followers_count
+   @attrs.followers_count
+end
+def friends_count
+   @attrs.friends_count
+end
+def geo_enabled
+   @attrs.geo_enabled
+end
+def is_translator
+   @attrs.is_translator
+end
+def lang
+   @attrs.lang
+end
+def listed_count
+   @attrs.listed_count
+end
+def location
+   @attrs.location
+end
+def name
+   @attrs.name
+end
+def notifications
+   @attrs.notifications
+end
+def profile_background_color
+   @attrs.profile_background_color
+end
+def profile_background_image_url
+   @attrs.profile_background_image_url
+end
+def profile_background_image_url_https
+   @attrs.profile_background_image_url_https
+end
+def profile_background_tile
+   @attrs.profile_background_tile
+end
+def profile_link_color
+   @attrs.profile_link_color
+end
+def profile_sidebar_border_color
+   @attrs.profile_sidebar_border_color
+end
+def profile_sidebar_fill_color
+   @attrs.profile_sidebar_fill_color
+end
+def profile_text_color
+   @attrs.profile_text_color
+end
+def profile_use_background_image
+   @attrs.profile_use_background_image
+end
+def protected
+   @attrs.protected
+end
+def statuses_count
+   @attrs.statuses_count
+end
+def time_zone
+   @attrs.time_zone
+end
+def utc_offset
+   @attrs.utc_offset
+end
+def verified
+   @attrs.verified
+end
+    
     def description_uris
       Array(@attrs[:entities][:description][:urls]).collect do |entity|
         Entity::URI.new(entity)


### PR DESCRIPTION
I made all the attr_reader's to public method's so that they can be accessed easily from `client` itself, instead from the `attrs` in the `@attrs` instance variable. This makes it so easy that you can do `client.user.favorite_count` to get the favorite count of a tweet.
