### PR TITLE
Fix documentation

### DIFF
--- a/lib/twitter/rest/friends_and_followers.rb
+++ b/lib/twitter/rest/friends_and_followers.rb
@@ -243,7 +243,7 @@ module Twitter
       # @see https://dev.twitter.com/docs/api/1.1/get/friends/list
       # @rate_limited Yes
       # @authentication Requires user context
-      # @raise [Twittera:Error::Unauthorized] Error raised when supplied user credentials are not valid.
+      # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [Twitter::Cursor]
       # @overload friends(options = {})
       #   Returns a cursored collection of user objects for every user the authenticated user is following (otherwise known as their "friends").


### PR DESCRIPTION
This pull fixes a link that was pointing to the wrong API docs.
