### PR TITLE
Correct retweet response. Retweeted status should be the original tweet

### DIFF
--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -300,9 +300,7 @@ module Twitter
 
       def post_retweet(tweet, options)
         response = post("/1.1/statuses/retweet/#{extract_id(tweet)}.json", options).body
-        retweeted_status = response.delete(:retweeted_status)
-        retweeted_status[:retweeted_status] = response
-        Twitter::Tweet.new(retweeted_status)
+        Twitter::Tweet.new(response)
       end
     end
   end

--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -19,7 +19,6 @@ module Twitter
     object_attr_reader :Metadata, :metadata
     object_attr_reader :Place, :place
     object_attr_reader :Tweet, :retweeted_status
-    alias_method :retweet, :retweeted_status
     alias_method :retweeted_tweet, :retweeted_status
     alias_method :retweet?, :retweeted_status?
     alias_method :retweeted_tweet?, :retweeted_status?

--- a/spec/twitter/rest/tweets_spec.rb
+++ b/spec/twitter/rest/tweets_spec.rb
@@ -347,8 +347,8 @@ describe Twitter::REST::Tweets do
       tweets = @client.retweet(25_938_088_801)
       expect(tweets).to be_an Array
       expect(tweets.first).to be_a Twitter::Tweet
-      expect(tweets.first.text).to eq("As for the Series, I'm for the Giants. Fuck Texas, fuck Nolan Ryan, fuck George Bush.")
-      expect(tweets.first.retweeted_tweet.text).to eq("RT @gruber: As for the Series, I'm for the Giants. Fuck Texas, fuck Nolan Ryan, fuck George Bush.")
+      expect(tweets.first.text).to eq("RT @gruber: As for the Series, I'm for the Giants. Fuck Texas, fuck Nolan Ryan, fuck George Bush.")
+      expect(tweets.first.retweeted_tweet.text).to eq("As for the Series, I'm for the Giants. Fuck Texas, fuck Nolan Ryan, fuck George Bush.")
       expect(tweets.first.retweeted_tweet.id).not_to eq(tweets.first.id)
     end
     context 'already retweeted' do
@@ -393,8 +393,8 @@ describe Twitter::REST::Tweets do
       tweets = @client.retweet!(25_938_088_801)
       expect(tweets).to be_an Array
       expect(tweets.first).to be_a Twitter::Tweet
-      expect(tweets.first.text).to eq("As for the Series, I'm for the Giants. Fuck Texas, fuck Nolan Ryan, fuck George Bush.")
-      expect(tweets.first.retweeted_tweet.text).to eq("RT @gruber: As for the Series, I'm for the Giants. Fuck Texas, fuck Nolan Ryan, fuck George Bush.")
+      expect(tweets.first.text).to eq("RT @gruber: As for the Series, I'm for the Giants. Fuck Texas, fuck Nolan Ryan, fuck George Bush.")
+      expect(tweets.first.retweeted_tweet.text).to eq("As for the Series, I'm for the Giants. Fuck Texas, fuck Nolan Ryan, fuck George Bush.")
       expect(tweets.first.retweeted_tweet.id).not_to eq(tweets.first.id)
     end
     context 'forbidden' do


### PR DESCRIPTION
I am suggesting to revert the fix for issuse #228. As opposed to Issue #228, the Twitter api response with original tweet as the retweeted_status is actually a correct behaviour. Similarly, all statuses list endpoints would consistently return the original tweet as the retweeted_status, whenever a retweet is encountered.

However, the fix for issue #228 somehow reversed the response from Twitter API for POST retweet, making the gem behaviour inconsistent when encountering a retweet.

Example,
Twitter API:
- GET statuses/user_timeline -> return original tweet as retweeted_status whenever a retweet is encountered.
- POST statuses/retweet/:id -> return original tweet as retweeted_status, nested in the new retweet created.

Twitter Gem:
- GET statuses/user_timeline -> return original tweet as retweeted_status whenever a retweet is encountered.
- POST statuses/retweet/:id -> return new retweet as retweeted_status, nested in the the original tweet.

Also, the name, "retweeted_status", implies the "status being retweeted", thus the fix on issue #228 is wrong as the developer who fixed #228 mistaken "retweeted_status" as "the status generated due to taking a retweet action". This might also suggests Twitter::Tweet with alias_method for retweet as retweeted_status is also wrong.

The twitter documentation, https://dev.twitter.com/docs/api/1.1/post/statuses/retweet/:id, has example demonstrating  that original tweet is the retweeted_status. (Although the summary of the api is confusing, which I will file a bug to api.)

Also, on a side note, Issue #228 thought that Twitter API has a bug and implemented a fix at the Gem level. I think this is a bad practice. If we think the API is faulty, we should file a bug to Twitter instead.
