### PR TITLE
Enable injection of custom TCP/SSL socket classes.

### DIFF
--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -9,13 +9,13 @@ module Twitter
   module Streaming
     class Client < Twitter::Client
       attr_writer :connection
-      attr_accessor :tcp_socket_klass, :ssl_socket_klass
+      attr_accessor :tcp_socket_class, :ssl_socket_class
 
       # Initializes a new Client object
       #
       # @param options [Hash] A customizable set of options.
-      # @option options [String] :tcp_socket_klass A class that Connection will use to create a new TCP socket.
-      # @option options [String] :ssl_socket_klass A class that Connection will use to create a new SSL socket.
+      # @option options [String] :tcp_socket_class A class that Connection will use to create a new TCP socket.
+      # @option options [String] :ssl_socket_class A class that Connection will use to create a new SSL socket.
       # @return [Twitter::Streaming::Client]
       def initialize(options = {})
         super

--- a/lib/twitter/streaming/connection.rb
+++ b/lib/twitter/streaming/connection.rb
@@ -6,15 +6,15 @@ module Twitter
   module Streaming
     class Connection
       def initialize(opts = {})
-        @tcp_socket_klass = opts.fetch(:tcp_socket_klass) { TCPSocket }
-        @ssl_socket_klass = opts.fetch(:ssl_socket_klass) { OpenSSL::SSL::SSLSocket }
+        @tcp_socket_class = opts.fetch(:tcp_socket_class) { TCPSocket }
+        @ssl_socket_class = opts.fetch(:ssl_socket_class) { OpenSSL::SSL::SSLSocket }
       end
-      attr_reader :tcp_socket_klass, :ssl_socket_klass
+      attr_reader :tcp_socket_class, :ssl_socket_class
 
       def stream(request, response, opts = {})
         client_context = OpenSSL::SSL::SSLContext.new
-        client         = @tcp_socket_klass.new(Resolv.getaddress(request.uri.host), request.uri.port)
-        ssl_client     = @ssl_socket_klass.new(client, client_context)
+        client         = @tcp_socket_class.new(Resolv.getaddress(request.uri.host), request.uri.port)
+        ssl_client     = @ssl_socket_class.new(client, client_context)
 
         ssl_client.connect
         request.stream(ssl_client)

--- a/spec/twitter/streaming/connection_spec.rb
+++ b/spec/twitter/streaming/connection_spec.rb
@@ -7,8 +7,8 @@ describe Twitter::Streaming::Connection do
       subject(:connection) { Twitter::Streaming::Connection.new }
 
       it 'sets the default socket classes' do
-        expect(connection.tcp_socket_klass).to eq TCPSocket
-        expect(connection.ssl_socket_klass).to eq OpenSSL::SSL::SSLSocket
+        expect(connection.tcp_socket_class).to eq TCPSocket
+        expect(connection.ssl_socket_class).to eq OpenSSL::SSL::SSLSocket
       end
     end
 
@@ -18,14 +18,14 @@ describe Twitter::Streaming::Connection do
 
       subject(:connection) do
         Twitter::Streaming::Connection.new(
-          :tcp_socket_klass => DummyTCPSocket,
-          :ssl_socket_klass => DummySSLSocket
+          :tcp_socket_class => DummyTCPSocket,
+          :ssl_socket_class => DummySSLSocket
         )
       end
 
       it 'sets the default socket classes' do
-        expect(connection.tcp_socket_klass).to eq DummyTCPSocket
-        expect(connection.ssl_socket_klass).to eq DummySSLSocket
+        expect(connection.tcp_socket_class).to eq DummyTCPSocket
+        expect(connection.ssl_socket_class).to eq DummySSLSocket
       end
     end
   end


### PR DESCRIPTION
Twitter::Streaming::Client class now accepts custom TCP/SSL socket
classes. It passes those along to Twitter::Streaming::Connection.

It's possible to inject custom sockets this way, which in turn
makes it easy to use Twitter::Streaming funcitonality with
Celluloid::IO.

Celluloid's Socket classes support both blocking and non-blocking
operations.

https://github.com/celluloid/celluloid-io/wiki/Using-Celluloid::IO-with-existing-Ruby-libraries
