### PR TITLE
Dont allow unacceptable IO objects in update_with_media

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -105,7 +105,7 @@ module Twitter
     # Raised when a Tweet includes media that doesn't have a to_io method
     class UnacceptableIO < StandardError
       def initialize
-        super("The IO object for media must respond to to_io")
+        super('The IO object for media must respond to to_io')
       end
     end
 

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -215,7 +215,7 @@ module Twitter
       # @option options [String] :display_coordinates Whether or not to put a pin on the exact coordinates a tweet has been sent from.
       # @option options [Boolean, String, Integer] :trim_user Each tweet returned in a timeline will include a user object with only the author's numerical ID when set to true, 't' or 1.
       def update_with_media(status, media, options = {})
-        raise Twitter::Error::UnacceptableIO.new unless media.respond_to?(:to_io)
+        fail Twitter::Error::UnacceptableIO.new unless media.respond_to?(:to_io)
 
         hash = options.dup
         hash[:in_reply_to_status_id] = hash.delete(:in_reply_to_status).id unless hash[:in_reply_to_status].nil?

--- a/spec/twitter/rest/tweets_spec.rb
+++ b/spec/twitter/rest/tweets_spec.rb
@@ -474,11 +474,10 @@ describe Twitter::REST::Tweets do
         expect(a_post('/1.1/statuses/update_with_media.json')).to have_been_made
       end
     end
-    context "A non IO object" do
-      it "raises an error" do
-        expect {
-          @client.update_with_media("You always have options", "Unacceptable IO")
-        }.to raise_error(Twitter::Error::UnacceptableIO)
+    context 'A non IO object' do
+      it 'raises an error' do
+        update = lambda { @client.update_with_media('You always have options', 'Unacceptable IO') }
+        expect { update.call }.to raise_error(Twitter::Error::UnacceptableIO)
       end
     end
     context 'already posted' do


### PR DESCRIPTION
We ran into a bug where a 401 error was returned for any File-like
object that didn't have a to_io method defined
(ActionPack::HttpUploadedFile in this case). 

Since the contract of this
object is to have a to_io method otherwise it will be included in the
oauth signature (cause of 401) then we should short circuit early on
when we know this is supposed to be a File like object. Later on we
aren't sure exactly when we include/exclude params from the signature.

```
twitter [raise-error-non-io] bundle exec rake verify_measurements
YARD-Coverage: 59.4% (threshold: 59.4%)
```
