### PR TITLE
Make the streaming API raise exceptions for status codes.

### DIFF
--- a/lib/twitter/streaming/response.rb
+++ b/lib/twitter/streaming/response.rb
@@ -16,9 +16,9 @@ module Twitter
         @parser << data
       end
 
-      def on_headers_complete(headers)
-        # TODO: handle response codes
-        p(:status_code => @parser.status_code, :header => headers) unless @parser.status_code == 200
+      def on_headers_complete(_headers)
+        error = Twitter::Error.errors[@parser.status_code]
+        fail error.new if error
       end
 
       def on_body(data)

--- a/spec/twitter/streaming/response_spec.rb
+++ b/spec/twitter/streaming/response_spec.rb
@@ -1,0 +1,21 @@
+require 'helper'
+
+describe Twitter::Streaming::Response do
+  subject { Twitter::Streaming::Response.new }
+
+  describe '#on_headers_complete' do
+    it 'should not error if status code is 200' do
+      expect do
+        subject << "HTTP/1.1 200 OK\r\nSome-Header: Woo\r\n\r\n"
+      end.to_not raise_error
+    end
+
+    Twitter::Error.errors.each do |code, klass|
+      it "should raise an exception of type #{klass} for status code #{code}" do
+        expect do
+          subject << "HTTP/1.1 #{code} NOK\r\nSome-Header: Woo\r\n\r\n"
+        end.to raise_error(klass)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We noticed while using this that it just put the headers when there was a problem, so we changed it to use the exception map already available under Twitter::Error.errors.
