### PR TITLE
Favorite rescued when trying to favorite a deleted tweet

### DIFF
--- a/lib/twitter/rest/favorites.rb
+++ b/lib/twitter/rest/favorites.rb
@@ -66,23 +66,21 @@ module Twitter
       # @overload favorite(*tweets, options)
       #   @param tweets [Enumerable<Integer, String, URI, Twitter::Tweet>] A collection of Tweet IDs, URIs, or objects.
       #   @param options [Hash] A customizable set of options.
-      # def favorite(*args)
-      #   arguments = Twitter::Arguments.new(args)
-      #   pmap(arguments) do |tweet|
-      #     begin
-      #       perform_with_object(:post, '/1.1/favorites/create.json', arguments.options.merge(:id => extract_id(tweet)), Twitter::Tweet)
-      #     rescue Twitter::Error::AlreadyFavorited
-      #       puts 'already favorited'
-      #       next
-      #     rescue Twitter::Error::NotFound
-      #       puts 'tweet not found'
-      #       next
-      #     end
-      #   end.compact
-      # end
-      # alias_method :fav, :favorite
-      # alias_method :fave, :favorite
-      # deprecate_alias :favorite_create, :favorite
+      def favorite(*args)
+        arguments = Twitter::Arguments.new(args)
+        pmap(arguments) do |tweet|
+          begin
+            perform_with_object(:post, '/1.1/favorites/create.json', arguments.options.merge(:id => extract_id(tweet)), Twitter::Tweet)
+          rescue Twitter::Error::AlreadyFavorited
+            next
+          rescue Twitter::Error::NotFound
+            next
+          end
+        end.compact
+      end
+      alias_method :fav, :favorite
+      alias_method :fave, :favorite
+      deprecate_alias :favorite_create, :favorite
 
       # Favorites the specified Tweets as the authenticating user and raises an error if one has already been favorited
       #

--- a/spec/fixtures/status_not_found.json
+++ b/spec/fixtures/status_not_found.json
@@ -1,0 +1,1 @@
+{"errors":[{"message": "Sorry, that page does not exist","code": 34}]}

--- a/spec/twitter/rest/favorites_spec.rb
+++ b/spec/twitter/rest/favorites_spec.rb
@@ -111,6 +111,14 @@ describe Twitter::REST::Favorites do
         expect { @client.favorite(25_938_088_801) }.not_to raise_error
       end
     end
+    context 'tweet does not exist' do
+      before do
+        stub_post('/1.1/favorites/create.json').with(:body => {:id => '25938088801'}).to_return(:status => 404, :body => fixture('status_not_found.json'), :headers => {:content_type => 'application/json; charset=utf-8'})
+      end
+      it 'does not raise an error' do
+        expect { @client.favorite(25_938_088_801) }.not_to raise_error
+      end
+    end
     context 'with a URI object passed' do
       it 'requests the correct resource' do
         tweet = URI.parse('https://twitter.com/sferik/status/25938088801')
@@ -161,6 +169,14 @@ describe Twitter::REST::Favorites do
       end
       it 'raises an AlreadyFavorited error' do
         expect { @client.favorite!(25_938_088_801) }.to raise_error(Twitter::Error::AlreadyFavorited)
+      end
+    end
+    context 'tweet does not exist' do
+      before do
+        stub_post('/1.1/favorites/create.json').with(:body => {:id => '25938088801'}).to_return(:status => 404, :body => fixture('status_not_found.json'), :headers => {:content_type => 'application/json; charset=utf-8'})
+      end
+      it 'raises a NotFound error' do
+        expect { @client.favorite!(25_938_088_801) }.to raise_error(Twitter::Error::NotFound)
       end
     end
     context 'with a URI object passed' do


### PR DESCRIPTION
The favorite method would hangup when trying to favorite a tweet that has been deleted before it has been favorited. 
