### PR TITLE
Namespace registered Faraday middleware

### DIFF
--- a/lib/twitter/rest/client.rb
+++ b/lib/twitter/rest/client.rb
@@ -59,15 +59,15 @@ module Twitter
       def middleware
         @middleware ||= Faraday::RackBuilder.new do |faraday|
           # Convert file uploads to Faraday::UploadIO objects
-          faraday.request :multipart_with_file
+          faraday.request :twitter_multipart_with_file
           # Checks for files in the payload, otherwise leaves everything untouched
           faraday.request :multipart
           # Encodes as "application/x-www-form-urlencoded" if not already encoded
           faraday.request :url_encoded
           # Handle error responses
-          faraday.response :raise_error
+          faraday.response :twitter_raise_error
           # Parse JSON response bodies
-          faraday.response :parse_json
+          faraday.response :twitter_parse_json
           # Set default HTTP adapter
           faraday.adapter :net_http
         end

--- a/lib/twitter/rest/request/multipart_with_file.rb
+++ b/lib/twitter/rest/request/multipart_with_file.rb
@@ -36,4 +36,4 @@ module Twitter
   end
 end
 
-Faraday::Request.register_middleware :multipart_with_file => Twitter::REST::Request::MultipartWithFile
+Faraday::Request.register_middleware :twitter_multipart_with_file => Twitter::REST::Request::MultipartWithFile

--- a/lib/twitter/rest/response/parse_json.rb
+++ b/lib/twitter/rest/response/parse_json.rb
@@ -28,4 +28,4 @@ module Twitter
   end
 end
 
-Faraday::Response.register_middleware :parse_json => Twitter::REST::Response::ParseJson
+Faraday::Response.register_middleware :twitter_parse_json => Twitter::REST::Response::ParseJson

--- a/lib/twitter/rest/response/raise_error.rb
+++ b/lib/twitter/rest/response/raise_error.rb
@@ -32,4 +32,4 @@ module Twitter
   end
 end
 
-Faraday::Response.register_middleware :raise_error => Twitter::REST::Response::RaiseError
+Faraday::Response.register_middleware :twitter_raise_error => Twitter::REST::Response::RaiseError


### PR DESCRIPTION
Just namespacing the code for a middleware in a module is, sadly, not enough, as the name when you register it might clash with middleware from other libraries that register the same type of middleware (for example, the [Diffbot ruby client](https://github.com/diffbot/diffbot-ruby-client) registers a `:parse_json` middleware, which provokes projects using both the twitter and diffbot gems to raise an error when an error response comes back from twitter.
