### PR TITLE
Add JRuby to the supported ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ versions:
 * Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1
+* JRuby 1.7 (Both 1.9 mode and 1.8 mode)
 
 If something doesn't work on one of these versions, it's a bug.
 


### PR DESCRIPTION
The travis-ci tests run against both jruby-18 and jruby-19, they are not allowed failures and both are green.
Seems to me, like not adding them was just an oversight. If it isn't I'd like to know the reasoning :-)

Cheers,
Tobi
