### PR TITLE
Fix documentation typo in favorites.rb

### DIFF
--- a/lib/twitter/rest/favorites.rb
+++ b/lib/twitter/rest/favorites.rb
@@ -89,9 +89,9 @@ module Twitter
       # @raise [Twitter::Error::NotFound] Error raised when tweet does not exist or has been deleted.
       # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [Array<Twitter::Tweet>] The favorited Tweets.
-      # @overload favorite(*tweets)
+      # @overload favorite!(*tweets)
       #   @param tweets [Enumerable<Integer, String, URI, Twitter::Tweet>] A collection of Tweet IDs, URIs, or objects.
-      # @overload favorite(*tweets, options)
+      # @overload favorite!(*tweets, options)
       #   @param tweets [Enumerable<Integer, String, URI, Twitter::Tweet>] A collection of Tweet IDs, URIs, or objects.
       #   @param options [Hash] A customizable set of options.
       def favorite!(*args)


### PR DESCRIPTION
I think these should be `favorite!` not `favorite` because this is documenting the `favorite!` method.

-- Arron
