### PR TITLE
Fix RuntimeError: can't modify frozen Addressable::URI

### DIFF
--- a/lib/twitter/user.rb
+++ b/lib/twitter/user.rb
@@ -90,7 +90,8 @@ module Twitter
     # @return [Addressable::URI] The URL to the user's website.
     def website
       if website_uris?
-        website_uris.first.expanded_url.dup
+        website_uri = website_uris.first.expanded_url
+        website_uri && website_uri.dup
       else
         Addressable::URI.parse(@attrs[:url])
       end


### PR DESCRIPTION
``` ruby
irb(main):011:0> user.website
RuntimeError: can't modify frozen Addressable::URI
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/addressable-2.3.6/lib/addressable/uri.rb:1658:in `normalized_fragment'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/addressable-2.3.6/lib/addressable/uri.rb:823:in `freeze'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/memoizable-0.4.2/lib/memoizable.rb:17:in `block in <module:Memoizable>'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/memoizable-0.4.2/lib/memoizable/method_builder.rb:117:in `call'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/memoizable-0.4.2/lib/memoizable/method_builder.rb:117:in `block (3 levels) in create_memoized_method'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/memoizable-0.4.2/lib/memoizable/memory.rb:63:in `block (3 levels) in fetch'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thread_safe-0.3.4/lib/thread_safe/cache.rb:58:in `fetch'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/memoizable-0.4.2/lib/memoizable/memory.rb:62:in `block (2 levels) in fetch'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/memoizable-0.4.2/lib/memoizable/memory.rb:61:in `block in fetch'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/thread_safe-0.3.4/lib/thread_safe/cache.rb:58:in `fetch'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/memoizable-0.4.2/lib/memoizable/memory.rb:60:in `fetch'
    from /usr/local/var/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/memoizable-0.4.2/lib/memoizable/method_builder.rb:116:in `block (2 levels) in create_memoized_method'
    from (irb):11
    from /usr/local/var/rbenv/versions/2.1.2/bin/irb:11:in `<main>'
```
