### PR TITLE
don't store the iterated tweets to save memory space 

### DIFF
--- a/lib/twitter/enumerable.rb
+++ b/lib/twitter/enumerable.rb
@@ -4,22 +4,30 @@ module Twitter
 
     # @return [Enumerator]
     def each(start = 0)
-      @page_record ||= 0
       return to_enum(:each, start) unless block_given?
-      slice_index = @page_record >= start ? 0 : start - @page_record
+      slice_index = get_slice_index(start)
       Array(@collection[slice_index..-1]).each do |element|
         yield(element)
       end
       unless last?
-        @page_record += @collection.size
-        @collection = []
-        fetch_next_page
+        blank_cached_tweets_and_fill_from_next_page
         each(start, &Proc.new)
       end
       self
     end
 
   private
+
+    def get_slice_index(start)
+      @page_record ||= 0
+      @page_record >= start ? 0 : start - @page_record
+    end
+
+    def blank_cached_tweets_and_fill_from_next_page
+      @page_record += @collection.size
+      @collection = []
+      fetch_next_page
+    end
 
     # @return [Boolean]
     def last?

--- a/lib/twitter/enumerable.rb
+++ b/lib/twitter/enumerable.rb
@@ -4,12 +4,15 @@ module Twitter
 
     # @return [Enumerator]
     def each(start = 0)
+      @page_record ||= 0
       return to_enum(:each, start) unless block_given?
-      Array(@collection[start..-1]).each do |element|
+      slice_index = @page_record >= start ? 0 : start - @page_record
+      Array(@collection[slice_index..-1]).each do |element|
         yield(element)
       end
       unless last?
-        start = [@collection.size, start].max
+        @page_record += @collection.size
+        @collection = []
         fetch_next_page
         each(start, &Proc.new)
       end

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -24,6 +24,12 @@ describe Twitter::SearchResults do
       expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '100'})).to have_been_made
       expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '3', include_entities: '1', max_id: '414071361066532863'})).to have_been_made
     end
+    it 'do not store the iterated tweets' do
+      count = 0
+      searched_tweets = @client.search('#freebandnames')
+      searched_tweets.each { count += 1 }
+      expect(searched_tweets.instance_variable_get(:@collection).size).to eq(3)
+    end
     context 'with start' do
       it 'iterates' do
         count = 0


### PR DESCRIPTION
Hey, @sferik 
I found when I searched for massive tweets ,I got my memory bloated. the reason is we always store and reference the tweets in our @collection array.
And the old used , or iterated ones, seems no use case in our code ,and I think storing the objects is the gem users' responsibility. 
This is one performance which will affect some users like me.
What do you think? 
will be good if we can merge this PR.
thanks.
