### PR TITLE
Add Rate Limit Status in Cursor and Introduce Cursor#each_page

### DIFF
--- a/lib/twitter/cursor.rb
+++ b/lib/twitter/cursor.rb
@@ -7,6 +7,7 @@ module Twitter
     include Twitter::Utils
     # @return [Hash]
     attr_reader :attrs
+    attr_reader :rate_limit
     alias_method :to_h, :attrs
     alias_method :to_hash, :to_h
     deprecate_alias :to_hsh, :to_hash
@@ -17,25 +18,42 @@ module Twitter
     # @param key [String, Symbol] The key to fetch the data from the response
     # @param klass [Class] The class to instantiate objects in the response
     # @param request [Twitter::Request]
+    # @param rate_limit [Twitter::RateLimit]
     # @return [Twitter::Cursor]
-    def initialize(attrs, key, klass, request)
+    def initialize(attrs, key, klass, request, rate_limit = nil) # rubocop:disable ParameterLists
       @key = key.to_sym
       @klass = klass
       @client = request.client
       @request_method = request.verb
       @path = request.path
       @options = request.options
+      @rate_limit = rate_limit
       @collection = []
       self.attrs = attrs
     end
 
-  private
+    # @return [Twitter::Cursor]
+    def each_page(&block)
+      loop do
+        results = @attrs.fetch(@key, []).map do |element|
+          (@klass ? @klass.new(element) : element)
+        end
+
+        block.call(results, self)
+
+        break if last?
+        fetch_next_page
+      end
+      self
+    end
 
     # @return [Integer]
     def next_cursor
       @attrs[:next_cursor] || -1
     end
     alias_method :next, :next_cursor
+
+  private
 
     # @return [Boolean]
     def last?
@@ -44,8 +62,9 @@ module Twitter
 
     # @return [Hash]
     def fetch_next_page
-      response = @client.send(@request_method, @path, @options.merge(:cursor => next_cursor)).body
-      self.attrs = response
+      response    = @client.send(@request_method, @path, @options.merge(:cursor => next_cursor))
+      @rate_limit = Twitter::RateLimit.new(response.response_headers)
+      self.attrs  = response.body
     end
 
     # @param attrs [Hash]

--- a/spec/twitter/cursor_spec.rb
+++ b/spec/twitter/cursor_spec.rb
@@ -4,9 +4,30 @@ describe Twitter::Cursor do
 
   describe '#each' do
     before do
-      @client = Twitter::REST::Client.new(:consumer_key => 'CK', :consumer_secret => 'CS', :access_token => 'AT', :access_token_secret => 'AS')
-      stub_get('/1.1/followers/ids.json').with(:query => {:cursor => '-1', :screen_name => 'sferik'}).to_return(:body => fixture('ids_list.json'), :headers => {:content_type => 'application/json; charset=utf-8'})
-      stub_get('/1.1/followers/ids.json').with(:query => {:cursor => '1305102810874389703', :screen_name => 'sferik'}).to_return(:body => fixture('ids_list2.json'), :headers => {:content_type => 'application/json; charset=utf-8'})
+      @client = Twitter::REST::Client.new(:consumer_key => 'CK', :consumer_secret => 'CS',
+                                          :access_token => 'AT', :access_token_secret => 'AS')
+
+      stub_get('/1.1/followers/ids.json').with(:query => {:cursor => '-1', :screen_name => 'sferik'}).to_return(
+        :body => fixture('ids_list.json'),
+        :headers => {:content_type => 'application/json; charset=utf-8'})
+
+      stub_get('/1.1/followers/ids.json').with(:query => {:cursor => '1305102810874389703', :screen_name => 'sferik'}).to_return(
+        :body => fixture('ids_list2.json'),
+        :headers => {:content_type => 'application/json; charset=utf-8'})
+
+      stub_get('/1.1/followers/ids.json').with(:query => {:cursor => '-1', :screen_name => 'jack'}).to_return(
+        :body => fixture('ids_list.json'),
+        :headers => {:content_type => 'application/json; charset=utf-8',
+                     'X-Rate-Limit-Limit'     => '15',
+                     'X-Rate-Limit-Remaining' => '11',
+                     'X-Rate-Limit-Reset'     => Time.now + 10 * 60})
+
+      stub_get('/1.1/followers/ids.json').with(:query => {:cursor => '1305102810874389703', :screen_name => 'jack'}).to_return(
+        :body => fixture('ids_list2.json'),
+        :headers => {:content_type => 'application/json; charset=utf-8',
+                     'X-Rate-Limit-Limit'     => '15',
+                     'X-Rate-Limit-Remaining' => '0',
+                     'X-Rate-Limit-Reset'     => Time.now + 10 * 60})
     end
     it 'requests the correct resources' do
       @client.follower_ids('sferik').each {}
@@ -24,6 +45,43 @@ describe Twitter::Cursor do
         @client.follower_ids('sferik').each(5) { count += 1 }
         expect(count).to eq(1)
       end
+    end
+    it 'handles the rate limit status' do
+      first = @client.follower_ids('jack')
+      expect(first.rate_limit).not_to be_nil
+      expect(first.rate_limit.remaining).to eq 11
+      expect(first.rate_limit.limit).to eq 15
+    end
+    it 'handles the rate limit status when its not set' do
+      first = @client.follower_ids('sferik')
+      expect(first.rate_limit).not_to be_nil
+      expect(first.rate_limit.remaining).to be_nil
+    end
+    it 'passes the rate limit status into the loop' do
+      all_results = []
+      @client.follower_ids('jack').each_page do |results, cursor|
+        expect(cursor).not_to be_nil
+        expect(cursor.next).not_to be_nil
+        expect(cursor.rate_limit).not_to be_nil
+        all_results << results
+      end
+      expect(all_results.size).to eq 2
+      expect(all_results[0]).to match_array [20_009_713, 22_469_930, 351_223_419]
+      expect(all_results[1]).to match_array [14_100_886, 14_509_199, 23_621_851]
+    end
+    it 'allows to break the loop based on rate limit status' do
+      @client.follower_ids('jack').each_page do |_, cursor|
+        break if cursor.rate_limit.remaining == 11
+      end
+      expect(a_get('/1.1/followers/ids.json').with(:query => {:cursor => '-1', :screen_name => 'jack'})).to have_been_made
+      expect(a_get('/1.1/followers/ids.json').with(:query => {:cursor => '1305102810874389703', :screen_name => 'jack'})).not_to have_been_made
+    end
+    it 'works to pass start cursor to request' do
+      first = @client.follower_ids('sferik')
+      expect(first.attrs[:ids]).to match_array [20_009_713, 22_469_930, 351_223_419]
+      second = @client.follower_ids('sferik', :cursor => first.next)
+      expect(second.attrs[:ids]).to match_array [14_100_886, 14_509_199, 23_621_851]
+      expect(second.next).to be 0
     end
   end
 


### PR DESCRIPTION
## Scope

At Product Hunt we've run into troubles with rate limits whilst fetching large collections (e.g. Kevin Rose's followers).

This PR intends to add support for reading such large collections per page and rescheduling the next page read at a later point if necessary, i.e.

``` ruby
client.follower_ids('kevinrose').each_page |results, cursor|
  # Process results

  if cursor.rate_limit.remaining == 0
    # Reschedule oneself with cursor.next at a later point
    break
  end
end
```

In order to achieve this the rate limit is added to the cursor, and the `Cursor#each_page` method is introduced.
