### PR TITLE
use --retry and --jobs to bundle install faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
-bundler_args: --without development
-env:
-  global:
-    - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
+
 rvm:
   - 1.9.3
   - 2.0.0
@@ -11,10 +8,18 @@ rvm:
   - jruby-head
   - rbx-2
   - ruby-head
+
+sudo: false
+
+bundler_args: --without development --retry=3 --jobs=3
+
+env:
+  global:
+    - JRUBY_OPTS="$JRUBY_OPTS --debug"
+
 matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: rbx-2
     - rvm: ruby-head
   fast_finish: true
-sudo: false


### PR DESCRIPTION
caching is also possible, but if you do choose to add it, it is highly recommended to also add `bundle update` in a `before_script` section
