### PR TITLE
Add page enumerator and access to the rate limit in the cursor

### DIFF
--- a/lib/twitter/cursor.rb
+++ b/lib/twitter/cursor.rb
@@ -28,6 +28,12 @@ module Twitter
       self.attrs = request.perform
     end
 
+    # @yield [Enumerator, Twitter::Cursor]
+    def each_page_with_cursor(start = 0)
+      return to_enum(:each_page_with_cursor, start) unless block_given?
+      each_page(start).each { |page| yield([page, self]) }
+    end
+
   private
 
     # @return [Integer]

--- a/lib/twitter/cursor.rb
+++ b/lib/twitter/cursor.rb
@@ -20,6 +20,7 @@ module Twitter
     def initialize(key, klass, request)
       @key = key.to_sym
       @klass = klass
+      @request = request
       @client = request.client
       @request_method = request.verb
       @path = request.path
@@ -32,6 +33,11 @@ module Twitter
     def each_page_with_cursor(start = 0)
       return to_enum(:each_page_with_cursor, start) unless block_given?
       each_page(start).each { |page| yield([page, self]) }
+    end
+
+    # @return [Twitter::RateLimit] The rate limit for the current cursor request
+    def rate_limit
+      @request.rate_limit
     end
 
   private
@@ -49,8 +55,8 @@ module Twitter
 
     # @return [Hash]
     def fetch_next_page
-      response = Twitter::REST::Request.new(@client, @request_method, @path, @options.merge(cursor: next_cursor)).perform
-      self.attrs = response
+      @request = Twitter::REST::Request.new(@client, @request_method, @path, @options.merge(cursor: next_cursor))
+      self.attrs = @request.perform
     end
 
     # @param attrs [Hash]

--- a/lib/twitter/enumerable.rb
+++ b/lib/twitter/enumerable.rb
@@ -5,13 +5,20 @@ module Twitter
     # @return [Enumerator]
     def each(start = 0)
       return to_enum(:each, start) unless block_given?
-      Array(@collection[start..-1]).each do |element|
-        yield(element)
+      each_page(start) do |elements|
+        elements.each { |element| yield element }
       end
+      self
+    end
+
+    # @return [Enumerator]
+    def each_page(start = 0)
+      return to_enum(:each_page, start) unless block_given?
+      yield Array(@collection[start..-1])
       unless last?
         start = [@collection.size, start].max
         fetch_next_page
-        each(start, &Proc.new)
+        each_page(start, &Proc.new)
       end
       self
     end

--- a/lib/twitter/enumerable.rb
+++ b/lib/twitter/enumerable.rb
@@ -2,6 +2,8 @@ module Twitter
   module Enumerable
     include ::Enumerable
 
+    METHODS = [:each, :each_page].freeze
+
     # @return [Enumerator]
     def each(start = 0)
       return to_enum(:each, start) unless block_given?

--- a/lib/twitter/rate_limit.rb
+++ b/lib/twitter/rate_limit.rb
@@ -26,5 +26,11 @@ module Twitter
       [(reset_at - Time.now).ceil, 0].max if reset_at
     end
     alias_method :retry_after, :reset_in
+
+    # @return [Boolean]
+    def reached?
+      remaining == 0
+    end
+    memoize :reached?
   end
 end

--- a/spec/shared_examples_for_enumerables.rb
+++ b/spec/shared_examples_for_enumerables.rb
@@ -1,10 +1,9 @@
 shared_examples_for 'an enumerable' do |opts|
-  describe '#each' do
-    it_behaves_like 'an enumerable method', :each, opts
+  Twitter::Enumerable::METHODS.each do |method|
+    it_behaves_like 'an enumerable method', method, opts
   end
 
   describe '#each_page' do
-    it_behaves_like 'an enumerable method', :each_page, opts
     it 'yields an enumerable' do
       enumerable.each_page { |page| expect(page).to be_an(Enumerable) }
     end

--- a/spec/shared_examples_for_enumerables.rb
+++ b/spec/shared_examples_for_enumerables.rb
@@ -1,0 +1,56 @@
+shared_examples_for 'an enumerable' do |opts|
+  describe '#each' do
+    it_behaves_like 'an enumerable method', :each, opts
+  end
+
+  describe '#each_page' do
+    it_behaves_like 'an enumerable method', :each_page, opts
+    it 'yields an enumerable' do
+      subject.each_page do |enumerable|
+        expect(enumerable).to be_an(Enumerable)
+      end
+    end
+  end
+end
+
+def enumerator_from_block_args(args)
+  args.flatten!(1)
+  if args[0].respond_to? :each
+    enumerator, _ = args
+  else
+    enumerator = args
+  end
+  enumerator
+end
+
+shared_examples_for 'an enumerable method' do |method, opts|
+  before do
+    opts         ||= {}
+    opts[:count] ||= 6
+    opts[:start] ||= 5
+  end
+  it 'iterates' do
+    count = 0
+    subject.send(method) do |*args|
+      enumerator_from_block_args(args).each { count += 1 }
+    end
+    expect(count).to eq(opts[:count])
+  end
+  context 'with start' do
+    before do
+      @count_after_start = opts[:count] - opts[:start]
+    end
+    it 'iterates' do
+      count = 0
+      subject.send(method, opts[:start]) do |*args|
+        enumerator_from_block_args(args).each { count += 1 }
+      end
+      expect(count).to eq(@count_after_start)
+    end
+  end
+  context 'when no block is given' do
+    it 'returns an enumerable object' do
+      expect(subject.send(method)).to be_an(Enumerable)
+    end
+  end
+end

--- a/spec/shared_examples_for_enumerables.rb
+++ b/spec/shared_examples_for_enumerables.rb
@@ -6,9 +6,7 @@ shared_examples_for 'an enumerable' do |opts|
   describe '#each_page' do
     it_behaves_like 'an enumerable method', :each_page, opts
     it 'yields an enumerable' do
-      subject.each_page do |enumerable|
-        expect(enumerable).to be_an(Enumerable)
-      end
+      enumerable.each_page { |page| expect(page).to be_an(Enumerable) }
     end
   end
 end
@@ -31,7 +29,7 @@ shared_examples_for 'an enumerable method' do |method, opts|
   end
   it 'iterates' do
     count = 0
-    subject.send(method) do |*args|
+    enumerable.send(method) do |*args|
       enumerator_from_block_args(args).each { count += 1 }
     end
     expect(count).to eq(opts[:count])
@@ -42,7 +40,7 @@ shared_examples_for 'an enumerable method' do |method, opts|
     end
     it 'iterates' do
       count = 0
-      subject.send(method, opts[:start]) do |*args|
+      enumerable.send(method, opts[:start]) do |*args|
         enumerator_from_block_args(args).each { count += 1 }
       end
       expect(count).to eq(@count_after_start)
@@ -50,7 +48,7 @@ shared_examples_for 'an enumerable method' do |method, opts|
   end
   context 'when no block is given' do
     it 'returns an enumerable object' do
-      expect(subject.send(method)).to be_an(Enumerable)
+      expect(enumerable.send(method)).to be_an(Enumerable)
     end
   end
 end

--- a/spec/twitter/cursor_spec.rb
+++ b/spec/twitter/cursor_spec.rb
@@ -1,27 +1,24 @@
 require 'helper'
+require 'shared_examples_for_enumerables'
 
 describe Twitter::Cursor do
-  describe '#each' do
+  let(:client) { Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS') }
+
+  subject { client.follower_ids('sferik') }
+
+  describe 'Enumeration Methods' do
+    it_behaves_like 'an enumerable'
+
     before do
-      @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS')
       stub_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'}).to_return(body: fixture('ids_list.json'), headers: {content_type: 'application/json; charset=utf-8'})
       stub_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'}).to_return(body: fixture('ids_list2.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
-    it 'requests the correct resources' do
-      @client.follower_ids('sferik').each {}
-      expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'})).to have_been_made
-      expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'})).to have_been_made
-    end
-    it 'iterates' do
-      count = 0
-      @client.follower_ids('sferik').each { count += 1 }
-      expect(count).to eq(6)
-    end
-    context 'with start' do
-      it 'iterates' do
-        count = 0
-        @client.follower_ids('sferik').each(5) { count += 1 }
-        expect(count).to eq(1)
+
+    [:each, :each_page].each do |method|
+      it 'requests the correct resources' do
+        subject.send(method) {}
+        expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'})).to have_been_made
+        expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'})).to have_been_made
       end
     end
   end

--- a/spec/twitter/cursor_spec.rb
+++ b/spec/twitter/cursor_spec.rb
@@ -13,7 +13,8 @@ describe Twitter::Cursor do
       stub_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'}).to_return(body: fixture('ids_list2.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
 
-    [:each, :each_page, :each_page_with_cursor].each do |method|
+    resource_methods = Twitter::Enumerable::METHODS + [:each_page_with_cursor]
+    resource_methods.each do |method|
       it 'requests the correct resources' do
         enumerable.send(method) {}
         expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'})).to have_been_made

--- a/spec/twitter/cursor_spec.rb
+++ b/spec/twitter/cursor_spec.rb
@@ -3,11 +3,10 @@ require 'shared_examples_for_enumerables'
 
 describe Twitter::Cursor do
   let(:client) { Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS') }
+  let(:cursor) { client.follower_ids('sferik') }
 
-  subject { client.follower_ids('sferik') }
-
-  describe 'Enumeration Methods' do
-    it_behaves_like 'an enumerable'
+  it_behaves_like 'an enumerable' do
+    let(:enumerable) { cursor }
 
     before do
       stub_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'}).to_return(body: fixture('ids_list.json'), headers: {content_type: 'application/json; charset=utf-8'})
@@ -16,7 +15,7 @@ describe Twitter::Cursor do
 
     [:each, :each_page, :each_page_with_cursor].each do |method|
       it 'requests the correct resources' do
-        subject.send(method) {}
+        enumerable.send(method) {}
         expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'})).to have_been_made
         expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'})).to have_been_made
       end
@@ -24,10 +23,9 @@ describe Twitter::Cursor do
 
     describe '#each_page_with_cursor' do
       it_behaves_like 'an enumerable method', :each_page_with_cursor
-
       it 'yields an enumerable and cursor' do
-        subject.each_page_with_cursor do |enumerable, cursor|
-          expect(enumerable).to be_an(Enumerable)
+        enumerable.each_page_with_cursor do |page, cursor|
+          expect(page).to be_an(Enumerable)
           expect(cursor).to be_a(Twitter::Cursor)
         end
       end
@@ -53,12 +51,10 @@ describe Twitter::Cursor do
           'X-Rate-Limit-Reset'     => Time.now + 10 * 60})
     end
     it 'returns a rate limit object' do
-      cursor = subject
       expect(cursor.rate_limit).to be_a(Twitter::RateLimit)
     end
     context 'when a new request is made' do
       it 'returns an updated rate limit' do
-        cursor = subject
         expect { cursor.take(5) }.to change { cursor.rate_limit.remaining }.from(1).to(0)
       end
     end

--- a/spec/twitter/cursor_spec.rb
+++ b/spec/twitter/cursor_spec.rb
@@ -13,15 +13,6 @@ describe Twitter::Cursor do
       stub_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'}).to_return(body: fixture('ids_list2.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
 
-    resource_methods = Twitter::Enumerable::METHODS + [:each_page_with_cursor]
-    resource_methods.each do |method|
-      it 'requests the correct resources' do
-        enumerable.send(method) {}
-        expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'})).to have_been_made
-        expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'})).to have_been_made
-      end
-    end
-
     describe '#each_page_with_cursor' do
       it_behaves_like 'an enumerable method', :each_page_with_cursor
       it 'yields an enumerable and cursor' do
@@ -29,6 +20,15 @@ describe Twitter::Cursor do
           expect(page).to be_an(Enumerable)
           expect(cursor).to be_a(Twitter::Cursor)
         end
+      end
+    end
+
+    resource_methods = Twitter::Enumerable::METHODS + [:each_page_with_cursor]
+    resource_methods.each do |method|
+      it 'requests the correct resources' do
+        enumerable.send(method) {}
+        expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'})).to have_been_made
+        expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'})).to have_been_made
       end
     end
   end

--- a/spec/twitter/cursor_spec.rb
+++ b/spec/twitter/cursor_spec.rb
@@ -37,7 +37,7 @@ describe Twitter::Cursor do
       stub_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'}).to_return(
         body: fixture('ids_list.json'),
         headers: {
-          'content_type'           => 'application/json; charset=utf-8',
+          :content_type            => 'application/json; charset=utf-8',
           'X-Rate-Limit-Limit'     => '15',
           'X-Rate-Limit-Remaining' => '1',
           'X-Rate-Limit-Reset'     => Time.now + 10 * 60})
@@ -45,7 +45,7 @@ describe Twitter::Cursor do
       stub_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'}).to_return(
         body: fixture('ids_list2.json'),
         headers: {
-          'content_type'           => 'application/json; charset=utf-8',
+          :content_type            => 'application/json; charset=utf-8',
           'X-Rate-Limit-Limit'     => '15',
           'X-Rate-Limit-Remaining' => '0',
           'X-Rate-Limit-Reset'     => Time.now + 10 * 60})

--- a/spec/twitter/cursor_spec.rb
+++ b/spec/twitter/cursor_spec.rb
@@ -14,11 +14,22 @@ describe Twitter::Cursor do
       stub_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'}).to_return(body: fixture('ids_list2.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
 
-    [:each, :each_page].each do |method|
+    [:each, :each_page, :each_page_with_cursor].each do |method|
       it 'requests the correct resources' do
         subject.send(method) {}
         expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '-1', screen_name: 'sferik'})).to have_been_made
         expect(a_get('/1.1/followers/ids.json').with(query: {cursor: '1305102810874389703', screen_name: 'sferik'})).to have_been_made
+      end
+    end
+
+    describe '#each_page_with_cursor' do
+      it_behaves_like 'an enumerable method', :each_page_with_cursor
+
+      it 'yields an enumerable and cursor' do
+        subject.each_page_with_cursor do |enumerable, cursor|
+          expect(enumerable).to be_an(Enumerable)
+          expect(cursor).to be_a(Twitter::Cursor)
+        end
       end
     end
   end

--- a/spec/twitter/geo_results_spec.rb
+++ b/spec/twitter/geo_results_spec.rb
@@ -2,9 +2,9 @@ require 'helper'
 require 'shared_examples_for_enumerables'
 
 describe Twitter::GeoResults do
-  subject { Twitter::GeoResults.new(result: {places: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]}) }
-
-  it_behaves_like 'an enumerable'
+  it_behaves_like 'an enumerable' do
+    let(:enumerable) { Twitter::GeoResults.new(result: {places: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]}) }
+  end
 
   describe '#token' do
     it 'returns a String when token is set' do

--- a/spec/twitter/geo_results_spec.rb
+++ b/spec/twitter/geo_results_spec.rb
@@ -1,23 +1,10 @@
 require 'helper'
+require 'shared_examples_for_enumerables'
 
 describe Twitter::GeoResults do
-  describe '#each' do
-    before do
-      @geo_results = Twitter::GeoResults.new(result: {places: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]})
-    end
-    it 'iterates' do
-      count = 0
-      @geo_results.each { count += 1 }
-      expect(count).to eq(6)
-    end
-    context 'with start' do
-      it 'iterates' do
-        count = 0
-        @geo_results.each(5) { count += 1 }
-        expect(count).to eq(1)
-      end
-    end
-  end
+  subject { Twitter::GeoResults.new(result: {places: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]}) }
+
+  it_behaves_like 'an enumerable'
 
   describe '#token' do
     it 'returns a String when token is set' do

--- a/spec/twitter/rate_limit_spec.rb
+++ b/spec/twitter/rate_limit_spec.rb
@@ -55,4 +55,22 @@ describe Twitter::RateLimit do
       expect(rate_limit.reset_in).to be_nil
     end
   end
+
+  describe '#reached?' do
+    it 'returns true when the remaining value is zero' do
+      rate_limit = Twitter::RateLimit.new('x-rate-limit-remaining' => '0')
+      expect(rate_limit.remaining).to eq 0
+      expect(rate_limit.reached?).to be true
+    end
+    it 'returns false when the remaining value is greater than zero' do
+      rate_limit = Twitter::RateLimit.new('x-rate-limit-remaining' => '149')
+      expect(rate_limit.remaining).to eq 149
+      expect(rate_limit.reached?).to be false
+    end
+    it 'returns false when the remaining value is nil' do
+      rate_limit = Twitter::RateLimit.new
+      expect(rate_limit.remaining).to be nil
+      expect(rate_limit.reached?).to be false
+    end
+  end
 end

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -3,10 +3,9 @@ require 'shared_examples_for_enumerables'
 
 describe Twitter::SearchResults do
   let(:client) { Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS') }
-  subject { client.search('#freebandnames') }
 
-  describe 'Enumeration Methods' do
-    it_behaves_like 'an enumerable'
+  it_behaves_like 'an enumerable' do
+    let(:enumerable) { client.search('#freebandnames')  }
 
     before do
       stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '100'}).to_return(body: fixture('search.json'), headers: {content_type: 'application/json; charset=utf-8'})

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -12,7 +12,7 @@ describe Twitter::SearchResults do
       stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '3', include_entities: '1', max_id: '414071361066532863'}).to_return(body: fixture('search2.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
 
-    [:each, :each_page].each do |method|
+    Twitter::Enumerable::METHODS.each do |method|
       it 'requests the correct resources' do
         client.search('#freebandnames').send(method) {}
         expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '100'})).to have_been_made

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -1,34 +1,31 @@
 require 'helper'
+require 'shared_examples_for_enumerables'
 
 describe Twitter::SearchResults do
-  describe '#each' do
+  let(:client) { Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS') }
+  subject { client.search('#freebandnames') }
+
+  describe 'Enumeration Methods' do
+    it_behaves_like 'an enumerable'
+
     before do
-      @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS')
       stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '100'}).to_return(body: fixture('search.json'), headers: {content_type: 'application/json; charset=utf-8'})
       stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '3', include_entities: '1', max_id: '414071361066532863'}).to_return(body: fixture('search2.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
-    it 'requests the correct resources' do
-      @client.search('#freebandnames').each {}
-      expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '100'})).to have_been_made
-      expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '3', include_entities: '1', max_id: '414071361066532863'})).to have_been_made
-    end
-    it 'iterates' do
-      count = 0
-      @client.search('#freebandnames').each { count += 1 }
-      expect(count).to eq(6)
-    end
-    it 'passes through parameters to the next request' do
-      stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '100'}).to_return(body: fixture('search.json'), headers: {content_type: 'application/json; charset=utf-8'})
-      stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '3', include_entities: '1', max_id: '414071361066532863'}).to_return(body: fixture('search2.json'), headers: {content_type: 'application/json; charset=utf-8'})
-      @client.search('#freebandnames', since_id: 414_071_360_078_878_542).each {}
-      expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '100'})).to have_been_made
-      expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '3', include_entities: '1', max_id: '414071361066532863'})).to have_been_made
-    end
-    context 'with start' do
-      it 'iterates' do
-        count = 0
-        @client.search('#freebandnames').each(5) { count += 1 }
-        expect(count).to eq(1)
+
+    [:each, :each_page].each do |method|
+      it 'requests the correct resources' do
+        client.search('#freebandnames').send(method) {}
+        expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '100'})).to have_been_made
+        expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', count: '3', include_entities: '1', max_id: '414071361066532863'})).to have_been_made
+      end
+
+      it 'passes through parameters to the next request' do
+        stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '100'}).to_return(body: fixture('search.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '3', include_entities: '1', max_id: '414071361066532863'}).to_return(body: fixture('search2.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        client.search('#freebandnames', since_id: 414_071_360_078_878_542).send(method) {}
+        expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '100'})).to have_been_made
+        expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '3', include_entities: '1', max_id: '414071361066532863'})).to have_been_made
       end
     end
   end

--- a/spec/twitter/trend_results_spec.rb
+++ b/spec/twitter/trend_results_spec.rb
@@ -1,6 +1,11 @@
 require 'helper'
+require 'shared_examples_for_enumerables'
 
 describe Twitter::TrendResults do
+  subject { Twitter::TrendResults.new(trends: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]) }
+
+  it_behaves_like 'an enumerable'
+
   describe '#as_of' do
     it 'returns a Time when as_of is set' do
       trend_results = Twitter::TrendResults.new(id: 1, as_of: '2012-08-24T23:25:43Z')
@@ -44,24 +49,6 @@ describe Twitter::TrendResults do
     it 'returns false when created_at is not set' do
       trend_results = Twitter::TrendResults.new(id: 1)
       expect(trend_results.created?).to be false
-    end
-  end
-
-  describe '#each' do
-    before do
-      @trend_results = Twitter::TrendResults.new(trends: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}])
-    end
-    it 'iterates' do
-      count = 0
-      @trend_results.each { count += 1 }
-      expect(count).to eq(6)
-    end
-    context 'with start' do
-      it 'iterates' do
-        count = 0
-        @trend_results.each(5) { count += 1 }
-        expect(count).to eq(1)
-      end
     end
   end
 

--- a/spec/twitter/trend_results_spec.rb
+++ b/spec/twitter/trend_results_spec.rb
@@ -2,9 +2,9 @@ require 'helper'
 require 'shared_examples_for_enumerables'
 
 describe Twitter::TrendResults do
-  subject { Twitter::TrendResults.new(trends: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]) }
-
-  it_behaves_like 'an enumerable'
+  it_behaves_like 'an enumerable' do
+    let(:enumerable) { Twitter::TrendResults.new(trends: [{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]) }
+  end
 
   describe '#as_of' do
     it 'returns a Time when as_of is set' do


### PR DESCRIPTION
This builds on @lfittl's pull request, https://github.com/sferik/twitter/pull/626, and uses sferik's comments to hopefully improve the interfaces between the `Enumerable`, `Cursor`, and `RateLimit` classes. With this we can check the state of the rate limit to ensure we don't exceed it:

```ruby
client.follower_ids(count: 500).each_page_with_cursor do |follower_ids, cursor|
  # do something with follower_ids

  break if cursor.rate_limit.reached?
end
```

I tried to DRY up the rpsec tests as best I could for the `Enumerable` classes. Any feedback is appreciated.