### PR TITLE
Patch 1

### DIFF
--- a/lib/twitter/search_results.rb
+++ b/lib/twitter/search_results.rb
@@ -9,7 +9,9 @@ module Twitter
     include Twitter::Enumerable
     include Twitter::Utils
     # @return [Hash]
-    attr_reader :attrs, :collection
+    attr_reader :attrs
+    # @return [Array<Twitter::Tweet>]
+    attr_reader :collection
     alias_method :to_h, :attrs
     alias_method :to_hash, :to_h
 

--- a/lib/twitter/search_results.rb
+++ b/lib/twitter/search_results.rb
@@ -9,7 +9,7 @@ module Twitter
     include Twitter::Enumerable
     include Twitter::Utils
     # @return [Hash]
-    attr_reader :attrs
+    attr_reader :attrs, :collection
     alias_method :to_h, :attrs
     alias_method :to_hash, :to_h
 

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -24,6 +24,9 @@ describe Twitter::SearchResults do
       expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '100'})).to have_been_made
       expect(a_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '3', include_entities: '1', max_id: '414071361066532863'})).to have_been_made
     end
+    it 'provides access to the collection' do
+      expect(@client.search('#freebandnames').respond_to? :collection).to be(true)
+    end
     context 'with start' do
       it 'iterates' do
         count = 0


### PR DESCRIPTION
I would like to have this while implementing a caching solution in Rails.  Attempting to cache the SearchResults object results in errors (something about not being able to cache Proc objects):

```ruby
Rails.cache.fetch("#{cache_key}/query", expires_in: CACHE_EXPIRY_TIME) do
  TwitterFeed.client.search("#{query}", lang: 'en').instance_variable_get("@collection")
end
```