### PR TITLE
Attempting to json-encode a Twitter::NullObject with ActiveSupport results in SystemStackError

### DIFF
--- a/lib/twitter/null_object.rb
+++ b/lib/twitter/null_object.rb
@@ -40,5 +40,9 @@ module Twitter
     def nil?
       true
     end
+
+    def as_json
+      'null'
+    end
   end
 end

--- a/spec/twitter/null_object_spec.rb
+++ b/spec/twitter/null_object_spec.rb
@@ -54,6 +54,12 @@ describe Twitter::NullObject do
     end
   end
 
+  describe '#as_json' do
+    it "returns 'null'" do
+      expect(subject.as_json).to eq('null')
+    end
+  end
+
   describe 'black hole' do
     it 'returns self for missing methods' do
       expect(subject.missing).to eq(subject)


### PR DESCRIPTION
Right after we upgraded to Rails 4.1, we started noticing periodic `SystemStackErrors` being raised by our application when performing and rendering results from `Twitter::REST::Client#search`. This appears to be caused by an interaction between `Twitter::NullObject` and `ActiveSupport::JSON::Encoding::JSONGemEncoder#jsonify`, where:

```ruby
null_attr = Twitter::NullObject.new
ActiveSupport::JSON.encode(null_attr)
```
results in an infinite loop:
```ruby
ActiveSupport::JSON::Encoding::JSONGemEncoder:79 - jsonify
Twitter::NullObject::GeneratedMethods:90 - method_missing
Twitter::NullObject::GeneratedMethods:27 - method_missing
ActiveSupport::JSON::Encoding::JSONGemEncoder:79 - jsonify
Twitter::NullObject::GeneratedMethods:90 - method_missing
Twitter::NullObject::GeneratedMethods:27 - method_missing
...
```
and eventually:
```ruby
SystemStackError: stack level too deep
```

This pull request gives `Twitter::NullObject` the knowledge that its json representation is `'null'`, and thereby allows `#jsonify` to exit its infinite recursion. This seems to me to be a reasonable addition to NullObject's responsibilities, though I can definitely see an argument that it shouldn't be concerned at all with json encoding. Let me know what you think and whether there are any additional changes you'd like me to make.