### PR TITLE
as_json is frequently called with an options hash

### DIFF
--- a/lib/twitter/null_object.rb
+++ b/lib/twitter/null_object.rb
@@ -41,7 +41,7 @@ module Twitter
       true
     end
 
-    def as_json
+    def as_json(*)
       'null'
     end
   end


### PR DESCRIPTION
I bundled directly from github and started testing out the change, but it turns out that ActiveSupport::JSON passes an options argument to as_json.  I should have known, given most as_json definitions accept an optional argument.  Super sorry about this one -- I should have fully tested this before submitting a PR. I've made this change on my local copy of the gem, and I now get the following output:

```ruby
irb(main):001:0> null_attr = Twitter::NullObject.new
=> <null>
irb(main):002:0> ActiveSupport::JSON.encode(null_attr)
=> "\"null\""
```