### PR TITLE
Properly escape stream parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ Metrics/MethodLength:
   CountComments: false
   Max: 15
 
+Metrics/ModuleLength:
+  Max: 150 # TODO: Lower to 100
+
 Metrics/ParameterLists:
   Max: 4
   CountKeywordArgs: true

--- a/etc/erd.rb
+++ b/etc/erd.rb
@@ -14,7 +14,8 @@ def nodize(klass)
   klass.name.tr(COLON, UNDERSCORE)
 end
 
-nodes, edges = {}, {}
+nodes = {}
+edges = {}
 
 twitter_objects = ObjectSpace.each_object(Class).select do |klass|
   klass.name.to_s.start_with?(NAMESPACE)

--- a/lib/twitter/factory.rb
+++ b/lib/twitter/factory.rb
@@ -10,7 +10,7 @@ module Twitter
       # @return [Twitter::Base]
       def new(method, klass, attrs = {})
         type = attrs.fetch(method.to_sym)
-        const_name = type.gsub(/\/(.?)/) { "::#{Regexp.last_match[1].upcase}" }.gsub(/(?:^|_)(.)/) { Regexp.last_match[1].upcase }
+        const_name = type.split('_').collect(&:capitalize).join
         klass.const_get(const_name.to_sym).new(attrs)
       end
     end

--- a/lib/twitter/rest/utils.rb
+++ b/lib/twitter/rest/utils.rb
@@ -234,7 +234,8 @@ module Twitter
       end
 
       def collect_user_ids_and_screen_names(users) # rubocop:disable MethodLength
-        user_ids, screen_names = [], []
+        user_ids = []
+        screen_names = []
         users.flatten.each do |user|
           case user
           when Integer

--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -120,7 +120,7 @@ module Twitter
 
       def to_url_params(params)
         params.collect do |param, value|
-          [param, URI.encode(value)].join('=')
+          [param, escape_value(value)].join('=')
         end.sort.join('&')
       end
 
@@ -129,6 +129,13 @@ module Twitter
           :accept     => '*/*',
           :user_agent => user_agent,
         }
+      end
+
+      RESERVED_CHARACTERS = /[^a-zA-Z0-9\-\.\_\~]/
+      def escape_value(value)
+        URI.escape(value.to_s, RESERVED_CHARACTERS)
+      rescue ArgumentError
+        URI.escape(value.to_s.force_encoding(Encoding::UTF_8), RESERVED_CHARACTERS)
       end
 
       def collect_user_ids(users)

--- a/spec/twitter/rest/client_spec.rb
+++ b/spec/twitter/rest/client_spec.rb
@@ -160,7 +160,8 @@ describe Twitter::REST::Client do
       expect(@client.send(:connection)).to respond_to(:run_request)
     end
     it 'memoizes the connection' do
-      c1, c2 = @client.send(:connection), @client.send(:connection)
+      c1 = @client.send(:connection)
+      c2 = @client.send(:connection)
       expect(c1.object_id).to eq(c2.object_id)
     end
   end

--- a/spec/twitter/streaming/client_spec.rb
+++ b/spec/twitter/streaming/client_spec.rb
@@ -119,4 +119,22 @@ describe Twitter::Streaming::Client do
       expect(objects[5].code).to eq('FALLING_BEHIND')
     end
   end
+
+  context '#escape_value' do
+    it 'properly encodes spaces and +' do
+      expect(@client.send(:escape_value, 'Ladies + Gentlemen')).to eq('Ladies%20%2B%20Gentlemen')
+    end
+
+    it 'properly encodes spaces and +' do
+      expect(@client.send(:escape_value, 'An encoded string!')).to eq('An%20encoded%20string%21')
+    end
+
+    it 'properly encodes spaces and +' do
+      expect(@client.send(:escape_value, 'Dogs, Cats & Mice')).to eq('Dogs%2C%20Cats%20%26%20Mice')
+    end
+
+    it 'handles wrongly encoded unicode strings' do
+      expect(@client.send(:escape_value, '☃'.force_encoding(Encoding::ASCII))).to eq('%E2%98%83')
+    end
+  end
 end

--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'buftok', '~> 0.2.0'
   spec.add_dependency 'equalizer', '0.0.10'
   spec.add_dependency 'faraday', '~> 0.9.0'
-  spec.add_dependency 'http', '~> 0.6.0'
+  spec.add_dependency 'http', ['>= 0.4', '< 0.9']
   spec.add_dependency 'http_parser.rb', '~> 0.6.0'
   spec.add_dependency 'json', '~> 1.8'
   spec.add_dependency 'memoizable', '~> 0.4.0'


### PR DESCRIPTION
Currently parameters passed to the streaming API are not encoded as per twitters [rules](https://dev.twitter.com/oauth/overview/percent-encoding-parameters). Filtering for `@twitter` results in a 401 error, easily reproducible  by running:

```
client.filter(track: '@twitter') { |tweet| puts tweet.text }
```

This PR fixes the problem for `5.x` releases.

The same PR can be applied to `master` but there the fix does not work, because of the`http` gem version. Version `0.8.3` introduced [HTTP::URI.parse(uri).normalize](https://github.com/httprb/http.rb/blob/v0.8.3/lib/http/request.rb#L70) which unescapes parts of the query string and thus produces the same exception as before:

```
properly_escaped_url = 'https://stream.twitter.com:443/1.1/statuses/filter.json?track=%40twitter'
puts HTTP::URI.parse(properly_escaped_url)
# -> https://stream.twitter.com:443/1.1/statuses/filter.json?track=%40twitter
puts HTTP::URI.parse(properly_escaped_url).normalize
# -> https://stream.twitter.com/1.1/statuses/filter.json?track=@twitter

```
