### PR TITLE
Aliased to_hash to to_h.  Allows libraries like RABL to gracefully handle nulls

### DIFF
--- a/lib/twitter/null_object.rb
+++ b/lib/twitter/null_object.rb
@@ -8,6 +8,8 @@ module Twitter
     config.define_explicit_conversions
     config.define_implicit_conversions
     config.predicates_return false
+    
+    alias_method :to_hash, :to_h
 
     def !
       true


### PR DESCRIPTION
After I recently upgraded the Twitter library, I kept getting "TypeError - Twitter::NullObject.to_hash() did not return a Hash." in our app.  I tracked the bug down to our RABL views calling the to_hash() on almost every property returned by Twitter::Tweet.  The change I made allows RABL to gracefully handle null objects.