### PR TITLE
Document 140 character limitation removal for Direct Messages

### DIFF
--- a/lib/twitter/rest/direct_messages.rb
+++ b/lib/twitter/rest/direct_messages.rb
@@ -23,6 +23,7 @@ module Twitter
       # @option options [Integer] :max_id Returns results with an ID less than (that is, older than) or equal to the specified ID.
       # @option options [Integer] :count Specifies the number of records to retrieve. Must be less than or equal to 200.
       # @option options [Integer] :page Specifies the page of results to retrieve.
+      # @option options [Boolean] :full_text Returns the full text of a DM when message text is longer than 140 characters.
       def direct_messages_received(options = {})
         perform_get_with_objects('/1.1/direct_messages.json', options, Twitter::DirectMessage)
       end
@@ -40,6 +41,7 @@ module Twitter
       # @option options [Integer] :max_id Returns results with an ID less than (that is, older than) or equal to the specified ID.
       # @option options [Integer] :count Specifies the number of records to retrieve. Must be less than or equal to 200.
       # @option options [Integer] :page Specifies the page of results to retrieve.
+      # @option options [Boolean] :full_text Returns the full text of a DM when message text is longer than 140 characters.
       def direct_messages_sent(options = {})
         perform_get_with_objects('/1.1/direct_messages/sent.json', options, Twitter::DirectMessage)
       end
@@ -54,6 +56,7 @@ module Twitter
       # @return [Twitter::DirectMessage] The requested messages.
       # @param id [Integer] A direct message ID.
       # @param options [Hash] A customizable set of options.
+      # @option options [Boolean] :full_text Returns the full text of a DM when message text is longer than 140 characters.
       def direct_message(id, options = {})
         options[:id] = id
         perform_get_with_object('/1.1/direct_messages/show.json', options, Twitter::DirectMessage)
@@ -120,7 +123,7 @@ module Twitter
       # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [Twitter::DirectMessage] The sent message.
       # @param user [Integer, String, Twitter::User] A Twitter user ID, screen name, URI, or object.
-      # @param text [String] The text of your direct message, up to 140 characters.
+      # @param text [String] The text of your direct message, up to 10,000 characters.
       # @param options [Hash] A customizable set of options.
       def create_direct_message(user, text, options = {})
         merge_user!(options, user)


### PR DESCRIPTION
Twitter has [announced API changes](https://twittercommunity.com/t/removing-the-140-character-limit-from-direct-messages/41348) related to the removal of the 140 character limitation