### PR TITLE
Fix proxy support

### DIFF
--- a/lib/twitter/streaming/connection.rb
+++ b/lib/twitter/streaming/connection.rb
@@ -10,21 +10,23 @@ module Twitter
       def initialize(options = {})
         @tcp_socket_class = options.fetch(:tcp_socket_class) { TCPSocket }
         @ssl_socket_class = options.fetch(:ssl_socket_class) { OpenSSL::SSL::SSLSocket }
+        @using_ssl        = options.fetch(:using_ssl)        { false }
       end
 
       def stream(request, response)
-        ssl_client = connect(request)
-        request.stream(ssl_client)
-        while body = ssl_client.readpartial(1024) # rubocop:disable AssignmentInCondition
+        client = connect(request)
+        request.stream(client)
+        while body = client.readpartial(1024) # rubocop:disable AssignmentInCondition
           response << body
         end
       end
 
       def connect(request)
-        client_context = OpenSSL::SSL::SSLContext.new
         client         = new_tcp_socket(request.socket_host, request.socket_port)
-        ssl_client     = @ssl_socket_class.new(client, client_context)
+        return client if !@using_ssl && request.using_proxy?
 
+        client_context = OpenSSL::SSL::SSLContext.new
+        ssl_client     = @ssl_socket_class.new(client, client_context)
         ssl_client.connect
       end
 

--- a/spec/twitter/streaming/connection_spec.rb
+++ b/spec/twitter/streaming/connection_spec.rb
@@ -63,11 +63,24 @@ describe Twitter::Streaming::Connection do
       let(:request) { HTTP::Request.new(method, uri, {}, proxy) }
 
       it 'requests via the proxy' do
-        expect(connection.ssl_socket_class).to receive(:new).and_return(ssl_socket)
-        allow(ssl_socket).to receive(:connect)
-
         expect(connection).to receive(:new_tcp_socket).with('127.0.0.1', 3328)
         connection.connect(request)
+      end
+
+      context "if using ssl" do
+
+        subject(:connection) do
+          Twitter::Streaming::Connection.new(tcp_socket_class: DummyTCPSocket, ssl_socket_class: DummySSLSocket, using_ssl: true)
+        end
+
+        it "connect with ssl" do
+          expect(connection.ssl_socket_class).to receive(:new).and_return(ssl_socket)
+          allow(ssl_socket).to receive(:connect)
+
+          expect(connection).to receive(:new_tcp_socket).with('127.0.0.1', 3328)
+          connection.connect(request)
+
+        end
       end
 
     end

--- a/spec/twitter/streaming/connection_spec.rb
+++ b/spec/twitter/streaming/connection_spec.rb
@@ -25,4 +25,52 @@ describe Twitter::Streaming::Connection do
       end
     end
   end
+
+  describe "connection" do
+
+    class DummyResponse
+      def initiailze(&block)
+        yield
+      end
+
+      def <<(data)
+
+      end
+    end
+
+    subject(:connection) do
+      Twitter::Streaming::Connection.new(tcp_socket_class: DummyTCPSocket, ssl_socket_class: DummySSLSocket)
+    end
+
+    let(:method) { :get }
+    let(:uri)    { 'https://stream.twitter.com:443/1.1/statuses/sample.json' }
+    let(:ssl_socket) { double("ssl_socket") }
+
+    let(:request) { HTTP::Request.new(method, uri, {}) }
+
+    it 'requests via the proxy' do
+      expect(connection.ssl_socket_class).to receive(:new).and_return(ssl_socket)
+      allow(ssl_socket).to receive(:connect)
+
+      expect(connection).to receive(:new_tcp_socket).with('stream.twitter.com', 443)
+      connection.connect(request)
+    end
+
+
+    context "when using a proxy" do
+
+      let(:proxy) { {proxy_address: '127.0.0.1', proxy_port: 3328} }
+      let(:request) { HTTP::Request.new(method, uri, {}, proxy) }
+
+      it 'requests via the proxy' do
+        expect(connection.ssl_socket_class).to receive(:new).and_return(ssl_socket)
+        allow(ssl_socket).to receive(:connect)
+
+        expect(connection).to receive(:new_tcp_socket).with('127.0.0.1', 3328)
+        connection.connect(request)
+      end
+
+    end
+  end
+
 end


### PR DESCRIPTION
While developing https://github.com/logstash-plugins/logstash-input-twitter/pull/29 I encountered some issues with this gem I tried to fix in this PR. I will try to summarize them here in benefit of a full context when reviewing this pr.

* httprb request object has changed it behaviour in recent versions, if you use ```request.uri.port``` it will return the port, but if the port is one of the standard ones, like ```443``` for ssl it will return nill. This is an issue breaking the connection as it's implemented in the ```Streaming::Connection``` class.
* If using a proxy, ```request.uri.host``` and ```request.uri.port``` will not be proxy aware, you should use ```request.socket_host``` and ```request.socket_port```.
* Forcing to connect with a proxy over a SSL connection has shown problematic, and according to the feedback I got, I must admit I'm not an expert, not common. So I introduced a flag that let you select SSL or not SSL when using a proxy. Keeps backwards compatibility.
* proxy configuration variables has changed in httprb, they are ```proxy_address```, ```proxy_port```.

/cheers
