### PR TITLE
Use built-in command to make form parameters

### DIFF
--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -110,19 +110,13 @@ module Twitter
       def request(method, uri, params)
         before_request.call
         headers = Twitter::Headers.new(self, method, uri, params).request_headers
-        request = HTTP::Request.new(method, uri + '?' + to_url_params(params), headers, proxy)
+        request = HTTP::Request.new(method, uri + '?' + URI.encode_www_form(params), headers, proxy)
         response = Streaming::Response.new do |data|
           if item = Streaming::MessageParser.parse(data) # rubocop:disable AssignmentInCondition
             yield(item)
           end
         end
         @connection.stream(request, response)
-      end
-
-      def to_url_params(params)
-        params.collect do |param, value|
-          [param, URI.encode(value)].join('=')
-        end.sort.join('&')
       end
 
       # Takes a mixed array of Integers and Twitter::User objects and returns a


### PR DESCRIPTION
There is a built-in command for making a form/encoded parameters in Ruby. If you don't want use the built-in command, which accpets a Hash object and coverts it to form/encoded parameters, you should use `URI.encode_www_form_component` method.

Failed test case in the current version:

```ruby
require 'twitter'

client = Twitter::Streaming::Client.new do |config|
  config.consumer_key        = 'YOUR_CONSUMER_KEY'
  config.consumer_secret     = 'YOUR_CONSUMER_SECRET'
  config.access_token        = 'YOUR_ACCESS_TOKEN'
  config.access_token_secret = 'YOUR_ACCESS_SECRET'
end

filter_params = {
  :track => ':),:-),: ),:D,=),:(,:-(,: (,:/,:-/,=(,(:,):,)-:,(-:,( :,) :,:-D,:-|,:|,|:,|-:',
  :language => 'es'
}
client.filter(filter_params) do |object|
  puts object.text if object.is_a?(Twitter::Tweet)
end
```