### PR TITLE
Remove the encoding of profile urls

### DIFF
--- a/lib/twitter/profile.rb
+++ b/lib/twitter/profile.rb
@@ -26,7 +26,7 @@ module Twitter
     # @param size [String, Symbol] The size of the image. Must be one of: 'mobile', 'mobile_retina', 'web', 'web_retina', 'ipad', or 'ipad_retina'
     # @return [Addressable::URI]
     def profile_banner_uri(size = :web)
-      parse_encoded_uri(insecure_uri([@attrs[:profile_banner_url], size].join('/'))) unless @attrs[:profile_banner_url].nil?
+      parse_uri(insecure_uri([@attrs[:profile_banner_url], size].join('/'))) unless @attrs[:profile_banner_url].nil?
     end
     alias_method :profile_banner_url, :profile_banner_uri
 
@@ -35,7 +35,7 @@ module Twitter
     # @param size [String, Symbol] The size of the image. Must be one of: 'mobile', 'mobile_retina', 'web', 'web_retina', 'ipad', or 'ipad_retina'
     # @return [Addressable::URI]
     def profile_banner_uri_https(size = :web)
-      parse_encoded_uri([@attrs[:profile_banner_url], size].join('/')) unless @attrs[:profile_banner_url].nil?
+      parse_uri([@attrs[:profile_banner_url], size].join('/')) unless @attrs[:profile_banner_url].nil?
     end
     alias_method :profile_banner_url_https, :profile_banner_uri_https
 
@@ -51,7 +51,7 @@ module Twitter
     # @param size [String, Symbol] The size of the image. Must be one of: 'mini', 'normal', 'bigger' or 'original'
     # @return [Addressable::URI]
     def profile_image_uri(size = :normal)
-      parse_encoded_uri(insecure_uri(profile_image_uri_https(size))) unless @attrs[:profile_image_url_https].nil?
+      parse_uri(insecure_uri(profile_image_uri_https(size))) unless @attrs[:profile_image_url_https].nil?
     end
     alias_method :profile_image_url, :profile_image_uri
 
@@ -66,7 +66,7 @@ module Twitter
       # https://a0.twimg.com/profile_images/1759857427/image1326743606.png
       # https://a0.twimg.com/profile_images/1759857427/image1326743606_mini.png
       # https://a0.twimg.com/profile_images/1759857427/image1326743606_bigger.png
-      parse_encoded_uri(@attrs[:profile_image_url_https].sub(PROFILE_IMAGE_SUFFIX_REGEX, profile_image_suffix(size))) unless @attrs[:profile_image_url_https].nil?
+      parse_uri(@attrs[:profile_image_url_https].sub(PROFILE_IMAGE_SUFFIX_REGEX, profile_image_suffix(size))) unless @attrs[:profile_image_url_https].nil?
     end
     alias_method :profile_image_url_https, :profile_image_uri_https
 
@@ -79,8 +79,8 @@ module Twitter
 
   private
 
-    def parse_encoded_uri(uri)
-      Addressable::URI.parse(URI.encode(uri))
+    def parse_uri(uri)
+      Addressable::URI.parse(uri)
     end
 
     def insecure_uri(uri)


### PR DESCRIPTION
Profile urls used to be strings.  Then they were URI::parse'd to return URI's.  URI only supports ascii strings, so URI.encode was quickly added so unicode urls didn't blow up.  

Then URI was switched for Addressible, which handles unicode just fine.  Can we remove the URI.encode to keep unicode urls?

This change does not break any specs.