### PR TITLE
Use addressable for building query string

### DIFF
--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -110,13 +110,19 @@ module Twitter
       def request(method, uri, params)
         before_request.call
         headers = Twitter::Headers.new(self, method, uri, params).request_headers
-        request = HTTP::Request.new(verb: method, uri: uri + '?' + URI.encode_www_form(params), headers: headers, proxy: proxy)
+        request = HTTP::Request.new(verb: method, uri: uri + '?' + to_url_params(params), headers: headers, proxy: proxy)
         response = Streaming::Response.new do |data|
           if item = Streaming::MessageParser.parse(data) # rubocop:disable AssignmentInCondition
             yield(item)
           end
         end
         @connection.stream(request, response)
+      end
+
+      def to_url_params(params)
+        uri = Addressable::URI.new
+        uri.query_values = params
+        uri.query
       end
 
       # Takes a mixed array of Integers and Twitter::User objects and returns a


### PR DESCRIPTION
As URI component of Ruby standard library only conforms with RFC3986 and
it doesn't encode `*` character and that leads to errors. It seems Addressable
library conforms with RFC3986, RFC3987 and RFC6570 and it encodes `*` character
as well.

Following test case will be failed in the current version and it returns
`Twitter::Error::Unauthorized` exception.

``` ruby
require 'twitter'

client = Twitter::Streaming::Client.new do |config|
  config.consumer_key        = 'YOUR_CONSUMER_KEY'
  config.consumer_secret     = 'YOUR_CONSUMER_SECRET'
  config.access_token        = 'YOUR_ACCESS_TOKEN'
  config.access_token_secret = 'YOUR_ACCESS_SECRET'
end

filter_params = {
  :track => '(*^0^*)',
  :language => 'es'
}
client.filter(filter_params) do |object|
  puts object.text if object.is_a?(Twitter::Tweet)
end
```
