### PR TITLE
changed upload conditional

### DIFF
--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -304,7 +304,7 @@ module Twitter
       #
       # @see https://dev.twitter.com/rest/public/uploading-media
       def upload(media) # rubocop:disable MethodLength, AbcSize
-        if !(File.basename(media) =~ /\.mp4$/)
+        if !(media.content_type.include? 'mp4')
           Twitter::REST::Request.new(self, :multipart_post, 'https://upload.twitter.com/1.1/media/upload.json', key: :media, file: media).perform
         else
           init = Twitter::REST::Request.new(self, :post, 'https://upload.twitter.com/1.1/media/upload.json',


### PR DESCRIPTION
### Summary

When trying to upload a video downloaded from an url using the `open(url)` method from `OpenURI` module, it goes into the wrong branch of the if conditional. The file name does not include the file extension. It returns something like this `#<File:/var/folders/6q/933hg4yd489701m7x0q00wlr0000gn/T/open-uri20160426-5628-qipyw2>`. So `File.basename(media) =~ /\.mp4$/` is always false. I changed that condition to `media.content_type.include? 'mp4'`
