### PR TITLE
Enable #update to accept a :media option

### DIFF
--- a/examples/Update.md
+++ b/examples/Update.md
@@ -37,24 +37,22 @@ client.update("I'm tweeting with @gem!", place_id: "df51dec6f4ee2b2c")
 Post an update with an image.
 
 ```ruby
-client.update_with_media("I'm tweeting with @gem!", File.new("/path/to/media.png"))
+client.update("I'm tweeting with @gem!", media: File.new("/path/to/media.png"))
 ```
 
 Post an update with a possibly-sensitive image.
 
 ```ruby
-client.update_with_media("I'm tweeting with @gem!", File.new("/path/to/sensitive-media.png"), possibly_sensitive: true)
+client.update("I'm tweeting with @gem!", media: File.new("/path/to/sensitive-media.png"), possibly_sensitive: true)
 ```
 
 Post an update with multiple images.
 
 ```ruby
 media = %w(/path/to/media1.png /path/to/media2.png).map { |filename| File.new(filename) }
-client.update_with_media("I'm tweeting with @gem!", media)
+client.update("I'm tweeting with @gem!", media: media)
 ```
 
-For more information, see the documentation for the [`#update`][update] and
-[`#update_with_media`][update_with_media] methods.
+For more information, see the documentation for the [`#update`][update] method.
 
 [update]: http://rdoc.info/gems/twitter/Twitter/REST/Tweets#update-instance_method
-[update_with_media]: http://rdoc.info/gems/twitter/Twitter/REST/Tweets#update_with_media-instance_method

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -205,7 +205,8 @@ module Twitter
 
       # Updates the authenticating user's status with media
       #
-      # @see https://dev.twitter.com/rest/reference/post/statuses/update_with_media
+      # @see https://dev.twitter.com/rest/reference/post/media/upload
+      # @see https://dev.twitter.com/rest/reference/post/statuses/update
       # @note A status update with text/media identical to the authenticating user's current status will NOT be ignored
       # @rate_limited No
       # @authentication Requires user context
@@ -237,7 +238,7 @@ module Twitter
       # @param tweet [Integer, String, URI, Twitter::Tweet] A Tweet ID, URI, or object.
       # @param options [Hash] A customizable set of options.
       # @option options [Integer] :maxwidth The maximum width in pixels that the embed should be rendered at. This value is constrained to be between 250 and 550 pixels.
-      # @option options [Boolean, String, Integer] :hide_media Specifies whether the embedded Tweet should automatically expand images which were uploaded via {https://dev.twitter.com/rest/reference/post/statuses/update_with_media POST statuses/update_with_media}. When set to either true, t or 1 images will not be expanded. Defaults to false.
+      # @option options [Boolean, String, Integer] :hide_media Specifies whether the embedded Tweet should automatically expand images which were uploaded via {https://dev.twitter.com/rest/reference/post/media/upload POST media/upload}. When set to either true, t or 1 images will not be expanded. Defaults to false.
       # @option options [Boolean, String, Integer] :hide_thread Specifies whether the embedded Tweet should automatically show the original message in the case that the embedded Tweet is a reply. When set to either true, t or 1 the original Tweet will not be shown. Defaults to false.
       # @option options [Boolean, String, Integer] :omit_script Specifies whether the embedded Tweet HTML should include a `<script>` element pointing to widgets.js. In cases where a page already includes widgets.js, setting this value to true will prevent a redundant script element from being included. When set to either true, t or 1 the `<script>` element will not be included in the embed HTML, meaning that pages must include a reference to widgets.js manually. Defaults to false.
       # @option options [String] :align Specifies whether the embedded Tweet should be left aligned, right aligned, or centered in the page. Valid values are left, right, center, and none. Defaults to none, meaning no alignment styles are specified for the Tweet.
@@ -264,7 +265,7 @@ module Twitter
       #   @param tweets [Enumerable<Integer, String, URI, Twitter::Tweet>] A collection of Tweet IDs, URIs, or objects.
       #   @param options [Hash] A customizable set of options.
       #   @option options [Integer] :maxwidth The maximum width in pixels that the embed should be rendered at. This value is constrained to be between 250 and 550 pixels.
-      #   @option options [Boolean, String, Integer] :hide_media Specifies whether the embedded Tweet should automatically expand images which were uploaded via {https://dev.twitter.com/rest/reference/post/statuses/update_with_media POST statuses/update_with_media}. When set to either true, t or 1 images will not be expanded. Defaults to false.
+      #   @option options [Boolean, String, Integer] :hide_media Specifies whether the embedded Tweet should automatically expand images which were uploaded via {https://dev.twitter.com/rest/reference/post/media/upload POST media/upload}. When set to either true, t or 1 images will not be expanded. Defaults to false.
       #   @option options [Boolean, String, Integer] :hide_thread Specifies whether the embedded Tweet should automatically show the original message in the case that the embedded Tweet is a reply. When set to either true, t or 1 the original Tweet will not be shown. Defaults to false.
       #   @option options [Boolean, String, Integer] :omit_script Specifies whether the embedded Tweet HTML should include a `<script>` element pointing to widgets.js. In cases where a page already includes widgets.js, setting this value to true will prevent a redundant script element from being included. When set to either true, t or 1 the `<script>` element will not be included in the embed HTML, meaning that pages must include a reference to widgets.js manually. Defaults to false.
       #   @option options [String] :align Specifies whether the embedded Tweet should be left aligned, right aligned, or centered in the page. Valid values are left, right, center, and none. Defaults to none, meaning no alignment styles are specified for the Tweet.

--- a/spec/twitter/rest/tweets_spec.rb
+++ b/spec/twitter/rest/tweets_spec.rb
@@ -240,6 +240,33 @@ describe Twitter::REST::Tweets do
         expect(a_post('/1.1/statuses/update.json').with(body: {status: 'Powerful cartoon by @BillBramhall: http://t.co/IOEbc5QoES', place_id: 'df51dec6f4ee2b2c'})).to have_been_made
       end
     end
+    context 'with one media image' do
+      before do
+        stub_post('/1.1/statuses/update.json').to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').to_return(body: fixture('upload.json'), headers: {content_type: 'application/json; charset=utf-8'})
+      end
+      it 'requests the correct resource' do
+        @client.update('Powerful cartoon by @BillBramhall: http://t.co/IOEbc5QoES', media: fixture('pbjt.gif'))
+        expect(a_request(:post, 'https://upload.twitter.com/1.1/media/upload.json')).to have_been_made
+        expect(a_post('/1.1/statuses/update.json')).to have_been_made
+      end
+      it 'returns a Tweet' do
+        tweet = @client.update('Powerful cartoon by @BillBramhall: http://t.co/IOEbc5QoES', media: fixture('pbjt.gif'))
+        expect(tweet).to be_a Twitter::Tweet
+        expect(tweet.text).to eq('Powerful cartoon by @BillBramhall: http://t.co/IOEbc5QoES')
+      end
+    end
+    context 'with multiple media images' do
+      before do
+        stub_post('/1.1/statuses/update.json').to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').to_return(body: fixture('upload.json'), headers: {content_type: 'application/json; charset=utf-8'})
+      end
+      it 'requests the correct resource' do
+        @client.update('You always have options', media: [fixture('me.jpeg'), fixture('me.jpeg')])
+        expect(a_request(:post, 'https://upload.twitter.com/1.1/media/upload.json')).to have_been_made.times(2)
+        expect(a_post('/1.1/statuses/update.json')).to have_been_made
+      end
+    end
   end
 
   describe '#update!' do


### PR DESCRIPTION
This PR is in reference to a couple of open issues, including: https://github.com/sferik/twitter/issues/760

Twitter recently deprecated `update_with_media` endpoint and advised developers to instead upload images and then post a status update with the media_ids (https://dev.twitter.com/rest/reference/post/statuses/update_with_media). This gem was already doing that 2-step process, at least on the master branch. However, it only offered this functionality through a now-legacy-named `update_with_media` method, which could lead to confusion.

To enable movement away from the legacy-named method, this PR adds support to the gem's `update` method to accept a `media` option that is either a single file or an array of files. 

Example usage: `client.update("I'm tweeting with @gem!", media: File.new("/path/to/media.png"))`

Let me know if you have any suggestions or feedback! I'm curious to hear what you had in mind for this functionality in the coming versions.
