### PR TITLE
Upgrade http gem to ~> 2.0 (drops Ruby 1.9 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
-  - jruby-19mode
+  - jruby-9.1.1.0
   - jruby-head
   - rbx-2
   - ruby-head

--- a/README.md
+++ b/README.md
@@ -231,11 +231,10 @@ command:
 This library aims to support and is [tested against][travis] the following Ruby
 versions:
 
-* Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1
 * Ruby 2.2
-* JRuby 1.7 (in Ruby 1.9 mode)
+* JRuby 9.1.1.0
 
 If something doesn't work on one of these versions, it's a bug.
 

--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_dependency 'buftok', '~> 0.2.0'
   spec.add_dependency 'equalizer', '~> 0.0.11'
-  spec.add_dependency 'http', '~> 1.0'
+  spec.add_dependency 'http', '~> 2.0'
   spec.add_dependency 'http-form_data', '~> 1.0'
   spec.add_dependency 'http_parser.rb', '~> 0.6.0'
   spec.add_dependency 'memoizable', '~> 0.4.0'


### PR DESCRIPTION
Not sure if you're ready to drop Ruby 1.9 support or not, but I thought I'd get the ball rolling on this...