### PR TITLE
Examples Index via README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,12 @@
+Examples Index
+====================
+
+- [All Tweets](AllTweets.md)
+- [Configuration](Configuration.md#configuration)
+    - [Application-only Authentication](Configuration.md#application-only-authentication)
+    - [Single-user Authentication](Configuration.md#single-user-authentication)
+    - [Streaming Clients](Configuration.md#streaming-clients)
+- [Rate Limits](RateLimiting.md#rate-limits)
+- [Search](Search.md#search)
+- [Streaming](Streaming.md#streaming)
+- [Update (Tweet)](Update.md#update)


### PR DESCRIPTION
An index page for the examples list, including subheadings. It wouldn't be a bad idea to add short summaries for each example.
