### PR TITLE
Image upload with too big image

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -20,6 +20,9 @@ module Twitter
     # Raised when Twitter returns the HTTP status code 403
     Forbidden = Class.new(ClientError)
 
+    # Raised when Twitter returns the HTTP status code 413
+    RequestEntityTooLarge = Class.new(ClientError)
+
     # Raised when a Tweet has already been favorited
     AlreadyFavorited = Class.new(Forbidden)
 
@@ -62,6 +65,7 @@ module Twitter
       403 => Twitter::Error::Forbidden,
       404 => Twitter::Error::NotFound,
       406 => Twitter::Error::NotAcceptable,
+      413 => Twitter::Error::RequestEntityTooLarge,
       422 => Twitter::Error::UnprocessableEntity,
       429 => Twitter::Error::TooManyRequests,
       500 => Twitter::Error::InternalServerError,


### PR DESCRIPTION
In https://dev.twitter.com/rest/reference/post/media/upload is following written:

```
Supported media types and filesize

Supported media types: jpg, png, gif, webp

Image file size must be <= 5 MB

The filesize limit above is enforced by the media upload endpoint. In addition, there is a separate product entity specific filesize limit which is applied when calling the Tweet creation (or similar) endpoints with media_id. For example, it is possible to upload a 5 MB image, but the Tweet creation endpoint requires images to be <= 3 MB.
```

Twitter returns a empty body and status code 413 when trying to upload a image which exceeds this size limit. This will lead to an unhelpful error for twitter gem users as it will lead to following:

```
irb(main):001:0> response_body = ''
=> ""
irb(main):002:0> response_body[:media_id]
TypeError: no implicit conversion of Symbol into Integer
        from (irb):2:in `[]'
        from (irb):2
        from /home/benny/.rubies/2.3.1/bin/irb:11:in `<main>'

```

This is happening here: https://github.com/sferik/twitter/blob/master/lib/twitter/rest/tweets.rb#L227
This PR fixes this in the way that it raises an exception here: https://github.com/sferik/twitter/blob/master/lib/twitter/rest/request.rb#L81 instead of passing the empty string (empty response body) further along.

I did not add an explicit spec for that as it seems to me in error spec all error cases are dynamically spec'd (adding an error includes this error automatically in the spec)