### PR TITLE
Remove Ruby 1.8 and 1.9 support for 5-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - jruby-18mode
-  - jruby-19mode
+  - jruby-9.1.1.0
   - jruby-head
   - rbx-2
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2

--- a/lib/twitter/base.rb
+++ b/lib/twitter/base.rb
@@ -139,7 +139,7 @@ module Twitter
   private
 
     def attr_falsey_or_empty?(key)
-      @attrs[key].nil? || @attrs[key] == false || @attrs[key].respond_to?(:empty?) && @attrs[key].empty?
+      !@attrs[key] || @attrs[key].respond_to?(:empty?) && @attrs[key].empty?
     end
 
     def attrs_for_object(key1, key2 = nil)

--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -60,7 +60,7 @@ module Twitter
     def validate_credentials!
       credentials.each do |credential, value|
         next if value.nil? || value == true || value == false || value.is_a?(String)
-        fail(Twitter::Error::ConfigurationError.new("Invalid #{credential} specified: #{value.inspect} must be a String."))
+        raise(Twitter::Error::ConfigurationError.new("Invalid #{credential} specified: #{value.inspect} must be a String."))
       end
     end
   end

--- a/lib/twitter/headers.rb
+++ b/lib/twitter/headers.rb
@@ -50,13 +50,8 @@ module Twitter
     #
     # @return [String]
     def bearer_token_credentials_auth_header
-      basic_auth_token = strict_encode64("#{@client.consumer_key}:#{@client.consumer_secret}")
+      basic_auth_token = Base64.strict_encode64("#{@client.consumer_key}:#{@client.consumer_secret}")
       "Basic #{basic_auth_token}"
-    end
-
-    # Base64.strict_encode64 is not available on Ruby 1.8.7
-    def strict_encode64(str)
-      Base64.encode64(str).delete("\n")
     end
   end
 end

--- a/lib/twitter/null_object.rb
+++ b/lib/twitter/null_object.rb
@@ -9,10 +9,9 @@ module Twitter
     config.define_implicit_conversions
     config.predicates_return false
 
-    # TODO: Add when support for Ruby 1.8.7 is dropped
-    # def !
-    #   true
-    # end
+    def !
+      true
+    end
 
     def respond_to?(*)
       true

--- a/lib/twitter/null_object.rb
+++ b/lib/twitter/null_object.rb
@@ -18,12 +18,12 @@ module Twitter
     end
 
     def instance_of?(klass)
-      fail(TypeError.new('class or module required')) unless klass.is_a?(Class)
+      raise(TypeError.new('class or module required')) unless klass.is_a?(Class)
       self.class == klass
     end
 
     def kind_of?(mod)
-      fail(TypeError.new('class or module required')) unless mod.is_a?(Module)
+      raise(TypeError.new('class or module required')) unless mod.is_a?(Module)
       self.class.ancestors.include?(mod)
     end
 

--- a/lib/twitter/rest/media.rb
+++ b/lib/twitter/rest/media.rb
@@ -16,7 +16,7 @@ module Twitter
       # @param media [File, Hash] A File object with your picture (PNG, JPEG or GIF)
       # @param options [Hash] A customizable set of options.
       def upload(media, options = {})
-        fail(Twitter::Error::UnacceptableIO.new) unless media.respond_to?(:to_io)
+        raise(Twitter::Error::UnacceptableIO.new) unless media.respond_to?(:to_io)
         base_url = 'https://upload.twitter.com'
         path = '/1.1/media/upload.json'
         conn = connection.dup

--- a/lib/twitter/rest/response/raise_error.rb
+++ b/lib/twitter/rest/response/raise_error.rb
@@ -10,9 +10,9 @@ module Twitter
           klass = Twitter::Error.errors[status_code]
           return unless klass
           if klass == Twitter::Error::Forbidden
-            fail(handle_forbidden_errors(response))
+            raise(handle_forbidden_errors(response))
           else
-            fail(klass.from_response(response))
+            raise(klass.from_response(response))
           end
         end
 

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -226,7 +226,7 @@ module Twitter
       # @option options [String] :display_coordinates Whether or not to put a pin on the exact coordinates a tweet has been sent from.
       # @option options [Boolean, String, Integer] :trim_user Each tweet returned in a timeline will include a user object with only the author's numerical ID when set to true, 't' or 1.
       def update_with_media(status, media, options = {})
-        fail(Twitter::Error::UnacceptableIO.new) unless media.respond_to?(:to_io)
+        raise(Twitter::Error::UnacceptableIO.new) unless media.respond_to?(:to_io)
         hash = options.dup
         hash[:in_reply_to_status_id] = hash.delete(:in_reply_to_status).id unless hash[:in_reply_to_status].nil?
         hash[:place_id] = hash.delete(:place).woeid unless hash[:place].nil?

--- a/lib/twitter/streaming/response.rb
+++ b/lib/twitter/streaming/response.rb
@@ -18,7 +18,7 @@ module Twitter
 
       def on_headers_complete(_headers)
         error = Twitter::Error.errors[@parser.status_code]
-        fail error.new if error
+        raise error.new if error
       end
 
       def on_body(data)

--- a/spec/twitter/null_object_spec.rb
+++ b/spec/twitter/null_object_spec.rb
@@ -3,7 +3,6 @@ require 'helper'
 describe Twitter::NullObject do
   describe '#!' do
     it 'returns true' do
-      pending 'Add when support for Ruby 1.8.7 is dropped'
       expect(!subject).to be true
     end
   end

--- a/spec/twitter/rest/oauth_spec.rb
+++ b/spec/twitter/rest/oauth_spec.rb
@@ -7,13 +7,11 @@ describe Twitter::REST::OAuth do
 
   describe '#token' do
     before do
-      # Faraday treats Basic Auth differently so we have to use the full URL with credentials
-      @oauth2_token_url = 'https://CK:CS@api.twitter.com/oauth2/token'
-      stub_request(:post, @oauth2_token_url).with(:body => {'grant_type' => 'client_credentials'}).to_return(:body => fixture('bearer_token.json'), :headers => {:content_type => 'application/json; charset=utf-8'})
+      stub_request(:post, 'https://api.twitter.com/oauth2/token').with(:body => 'grant_type=client_credentials').to_return(:body => fixture('bearer_token.json'), :headers => {:content_type => 'application/json; charset=utf-8', :authorization => "Basic #{Base64.encode64('CK:CS')}"})
     end
     it 'requests the correct resource' do
       @client.token
-      expect(a_request(:post, @oauth2_token_url).with(:body => {:grant_type => 'client_credentials'}, :headers => {:content_type => 'application/x-www-form-urlencoded; charset=UTF-8', :accept => '*/*'})).to have_been_made
+      expect(a_request(:post, 'https://api.twitter.com/oauth2/token').with(:body => {:grant_type => 'client_credentials'}, :headers => {:content_type => 'application/x-www-form-urlencoded; charset=UTF-8', :accept => '*/*'})).to have_been_made
     end
     it 'returns the bearer token' do
       bearer_token = @client.token


### PR DESCRIPTION
- rake requires 1.9+ now: https://github.com/ruby/rake/pull/86
- tins requires 2.0+ now: https://github.com/flori/tins/commit/9ebb625d8a987bd54526006441ff97bc14c30e53
- Fix Basic Auth test

This Pull Request [failed with RuboCop](https://travis-ci.org/sferik/twitter/builds/157054504), should I fix it too?