### PR TITLE
Add email attribute reader to User

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Style/EachWithObject:
 Style/Encoding:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
@@ -56,5 +59,5 @@ Style/RaiseArgs:
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+5.16.0
+------
+* [Add new settings to `Twitter::Settings`](https://github.com/sferik/twitter/commit/d047ce00034d26a99927076c28679ce08fd69308)
+* [Add `Twitter::Trend#tweet_volume`](https://github.com/sferik/twitter/commit/e797b62e5e6a768e8aeafde6186e1f5310e6bfc6)
+* [Remove the encoding of profile urls](https://github.com/sferik/twitter/commit/6d46bd689ab4a4f119d1d692488aab37e4e99893) ([@TimHaines](https://twitter.com/TimHaines))
+* [Fix issue with port number in streaming connection](https://github.com/sferik/twitter/issues/709)
+
 5.15.0
 ------
 * [`NullObject#as_json` returns 'null'](https://github.com/sferik/twitter/commit/2979e703c09a45f012cb2c5b2d6663bf1f4d3351) ([@lukevmorris](https://twitter.com/lukevmorris))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+5.15.0
+------
+* [`NullObject#as_json` returns 'null'](https://github.com/sferik/twitter/commit/2979e703c09a45f012cb2c5b2d6663bf1f4d3351) ([@lukevmorris](https://twitter.com/lukevmorris))
+* [Add methods to get to parameters of quoted tweet](https://github.com/sferik/twitter/commit/afd41a3e36cc94194a2110ba9adce13486ced9fd) ([@couhie](https://twitter.com/couhie))
+* [Add additional mime_types for multi-part upload](https://github.com/sferik/twitter/commit/947fcdc9f7348f267d74933ffa43d191cf248a9c)
+* [Fix bug where flat_pmap can return nil](https://github.com/sferik/twitter/commit/e22a5601ec702632510b3e983e50929ceb334b95)
+* [Add new error codes](https://github.com/sferik/twitter/commit/1ce6b2f02d0f5f78435ee898e8f5b6d3db18d6f1)
+
 5.14.0
 ------
 * [Add `Twitter::NullObject#respond_to?`](https://github.com/sferik/twitter/commit/438e311d93f382960650e20898203c880ade6b25)

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
   gem 'rspec', '>= 2.14'
-  gem 'rubocop', '>= 0.27', :platforms => [:ruby_19, :ruby_20, :ruby_21]
+  gem 'rubocop', '>= 0.36', :platforms => [:ruby_19, :ruby_20, :ruby_21]
   gem 'simplecov', '>= 0.9'
   gem 'timecop', '0.6.1'
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'addressable', '~> 2.3.8', :platforms => [:jruby, :ruby_18]
 gem 'jruby-openssl', :platforms => :jruby
 gem 'rake'
 gem 'yard'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2015 Erik Michaels-Ober, John Nunemaker, Wynn Netherland, Steve Richert, Steve Agalloco
+Copyright (c) 2006-2016 Erik Michaels-Ober, John Nunemaker, Wynn Netherland, Steve Richert, Steve Agalloco
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Constraint][pvc] with two digits of precision. For example:
 [pvc]: http://guides.rubygems.org/patterns/#pessimistic-version-constraint
 
 ## Copyright
-Copyright (c) 2006-2015 Erik Michaels-Ober, John Nunemaker, Wynn Netherland, Steve Richert, Steve Agalloco.
+Copyright (c) 2006-2016 Erik Michaels-Ober, John Nunemaker, Wynn Netherland, Steve Richert, Steve Agalloco.
 See [LICENSE][] for details.
 
 [license]: LICENSE.md

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 task :erd do
-  FORMAT = 'svg'
+  FORMAT = 'svg'.freeze
   `bundle exec ruby ./etc/erd.rb > ./etc/erd.dot`
   `dot -T #{FORMAT} ./etc/erd.dot -o ./etc/erd.#{FORMAT}`
 end

--- a/etc/erd.rb
+++ b/etc/erd.rb
@@ -1,9 +1,9 @@
 require 'twitter'
 
-COLON = ':'
-UNDERSCORE = '_'
-TAB = "\t"
-NAMESPACE = 'Twitter::'
+COLON = ':'.freeze
+UNDERSCORE = '_'.freeze
+TAB = "\t".freeze
+NAMESPACE = 'Twitter::'.freeze
 
 # Colons are invalid characters in DOT nodes.
 # Replace them with underscores.

--- a/etc/erd.rb
+++ b/etc/erd.rb
@@ -47,9 +47,9 @@ end
 puts 'digraph classes {'
 # Add or remove DOT formatting options here
 indent do
-  puts "graph [rotate=0, rankdir=\"LR\"]"
-  puts "node [fillcolor=\"#c4ddec\", style=\"filled\", fontname=\"Helvetica Neue\"]"
-  puts "edge [color=\"#444444\"]"
+  puts 'graph [rotate=0, rankdir="LR"]'
+  puts 'node [fillcolor="#c4ddec", style="filled", fontname="Helvetica Neue"]'
+  puts 'edge [color="#444444"]'
   nodes.sort.each do |node, label|
     puts "#{node} [label=\"#{label}\"]"
   end

--- a/lib/twitter/base.rb
+++ b/lib/twitter/base.rb
@@ -87,13 +87,11 @@ module Twitter
         define_method(key1) do ||
           if attr_falsey_or_empty?(key1)
             NullObject.new
+          elsif klass.nil?
+            @attrs[key1]
           else
-            if klass.nil?
-              @attrs[key1]
-            else
-              attrs = attrs_for_object(key1, key2)
-              Twitter.const_get(klass).new(attrs)
-            end
+            attrs = attrs_for_object(key1, key2)
+            Twitter.const_get(klass).new(attrs)
           end
         end
         memoize(key1)

--- a/lib/twitter/base.rb
+++ b/lib/twitter/base.rb
@@ -11,8 +11,8 @@ module Twitter
     include Twitter::Utils
     # @return [Hash]
     attr_reader :attrs
-    alias_method :to_h, :attrs
-    alias_method :to_hash, :to_h
+    alias to_h attrs
+    alias to_hash to_h
     deprecate_alias :to_hsh, :to_hash
 
     class << self

--- a/lib/twitter/configuration.rb
+++ b/lib/twitter/configuration.rb
@@ -10,8 +10,8 @@ module Twitter
     # @return [Integer]
     attr_reader :characters_reserved_per_media, :max_media_per_upload,
                 :photo_size_limit, :short_url_length, :short_url_length_https
-    alias_method :short_uri_length, :short_url_length
-    alias_method :short_uri_length_https, :short_url_length_https
+    alias short_uri_length short_url_length
+    alias short_uri_length_https short_url_length_https
 
     # Returns an array of photo sizes
     #

--- a/lib/twitter/cursor.rb
+++ b/lib/twitter/cursor.rb
@@ -8,8 +8,8 @@ module Twitter
     include Twitter::Utils
     # @return [Hash]
     attr_reader :attrs
-    alias_method :to_h, :attrs
-    alias_method :to_hash, :to_h
+    alias to_h attrs
+    alias to_hash to_h
     deprecate_alias :to_hsh, :to_hash
 
     # Initializes a new Cursor
@@ -35,7 +35,7 @@ module Twitter
     def next_cursor
       @attrs[:next_cursor] || -1
     end
-    alias_method :next, :next_cursor
+    alias next next_cursor
 
     # @return [Boolean]
     def last?

--- a/lib/twitter/direct_message.rb
+++ b/lib/twitter/direct_message.rb
@@ -8,7 +8,7 @@ module Twitter
     include Twitter::Entities
     # @return [String]
     attr_reader :text
-    alias_method :full_text, :text
+    alias full_text text
     object_attr_reader :User, :recipient
     object_attr_reader :User, :sender
   end

--- a/lib/twitter/entities.rb
+++ b/lib/twitter/entities.rb
@@ -61,13 +61,13 @@ module Twitter
       entities(Entity::URI, :urls)
     end
     memoize :uris
-    alias_method :urls, :uris
+    alias urls uris
 
     # @return [Boolean]
     def uris?
       uris.any?
     end
-    alias_method :urls?, :uris?
+    alias urls? uris?
 
     # @note Must include entities in your request for this method to work
     # @return [Array<Twitter::Entity::UserMention>]

--- a/lib/twitter/geo.rb
+++ b/lib/twitter/geo.rb
@@ -6,6 +6,6 @@ module Twitter
     include Equalizer.new(:coordinates)
     # @return [Array<Float>]
     attr_reader :coordinates
-    alias_method :coords, :coordinates
+    alias coords coordinates
   end
 end

--- a/lib/twitter/geo/point.rb
+++ b/lib/twitter/geo/point.rb
@@ -7,14 +7,14 @@ module Twitter
       def latitude
         coordinates[0]
       end
-      alias_method :lat, :latitude
+      alias lat latitude
 
       # @return [Integer]
       def longitude
         coordinates[1]
       end
-      alias_method :long, :longitude
-      alias_method :lng, :longitude
+      alias long longitude
+      alias lng longitude
     end
   end
 end

--- a/lib/twitter/geo_results.rb
+++ b/lib/twitter/geo_results.rb
@@ -7,8 +7,8 @@ module Twitter
     include Twitter::Utils
     # @return [Hash]
     attr_reader :attrs
-    alias_method :to_h, :attrs
-    alias_method :to_hash, :to_h
+    alias to_h attrs
+    alias to_hash to_h
     deprecate_alias :to_hsh, :to_hash
 
     # Initializes a new GeoResults object

--- a/lib/twitter/list.rb
+++ b/lib/twitter/list.rb
@@ -16,21 +16,21 @@ module Twitter
       Addressable::URI.parse("#{uri}/members") if uri?
     end
     memoize :members_uri
-    alias_method :members_url, :members_uri
+    alias members_url members_uri
 
     # @return [Addressable::URI] The URI to the list subscribers.
     def subscribers_uri
       Addressable::URI.parse("#{uri}/subscribers") if uri?
     end
     memoize :subscribers_uri
-    alias_method :subscribers_url, :subscribers_uri
+    alias subscribers_url subscribers_uri
 
     # @return [Addressable::URI] The URI to the list.
     def uri
       Addressable::URI.parse("https://twitter.com/#{user.screen_name}/#{slug}") if slug? && user.screen_name?
     end
     memoize :uri
-    alias_method :url, :uri
+    alias url uri
 
     def uri?
       !!uri

--- a/lib/twitter/place.rb
+++ b/lib/twitter/place.rb
@@ -9,11 +9,11 @@ module Twitter
     attr_reader :attributes
     # @return [String]
     attr_reader :country, :full_name, :name
-    alias_method :woe_id, :id
-    alias_method :woeid, :id
+    alias woe_id id
+    alias woeid id
     object_attr_reader :GeoFactory, :bounding_box
     object_attr_reader :Place, :contained_within
-    alias_method :contained?, :contained_within?
+    alias contained? contained_within?
     uri_attr_reader :uri
 
     # Initializes a new place

--- a/lib/twitter/profile.rb
+++ b/lib/twitter/profile.rb
@@ -28,7 +28,7 @@ module Twitter
     def profile_banner_uri(size = :web)
       parse_uri(insecure_uri([@attrs[:profile_banner_url], size].join('/'))) unless @attrs[:profile_banner_url].nil?
     end
-    alias_method :profile_banner_url, :profile_banner_uri
+    alias profile_banner_url profile_banner_uri
 
     # Return the secure URL to the user's profile banner image
     #
@@ -37,7 +37,7 @@ module Twitter
     def profile_banner_uri_https(size = :web)
       parse_uri([@attrs[:profile_banner_url], size].join('/')) unless @attrs[:profile_banner_url].nil?
     end
-    alias_method :profile_banner_url_https, :profile_banner_uri_https
+    alias profile_banner_url_https profile_banner_uri_https
 
     # @return [Boolean]
     def profile_banner_uri?
@@ -53,7 +53,7 @@ module Twitter
     def profile_image_uri(size = :normal)
       parse_uri(insecure_uri(profile_image_uri_https(size))) unless @attrs[:profile_image_url_https].nil?
     end
-    alias_method :profile_image_url, :profile_image_uri
+    alias profile_image_url profile_image_uri
 
     # Return the secure URL to the user's profile image
     #
@@ -68,7 +68,7 @@ module Twitter
       # https://a0.twimg.com/profile_images/1759857427/image1326743606_bigger.png
       parse_uri(@attrs[:profile_image_url_https].sub(PROFILE_IMAGE_SUFFIX_REGEX, profile_image_suffix(size))) unless @attrs[:profile_image_url_https].nil?
     end
-    alias_method :profile_image_url_https, :profile_image_uri_https
+    alias profile_image_url_https profile_image_uri_https
 
     # @return [Boolean]
     def profile_image_uri?

--- a/lib/twitter/rate_limit.rb
+++ b/lib/twitter/rate_limit.rb
@@ -29,6 +29,6 @@ module Twitter
     def reset_in
       [(reset_at - Time.now).ceil, 0].max if reset_at
     end
-    alias_method :retry_after, :reset_in
+    alias retry_after reset_in
   end
 end

--- a/lib/twitter/rest/client.rb
+++ b/lib/twitter/rest/client.rb
@@ -12,7 +12,7 @@ module Twitter
   module REST
     class Client < Twitter::Client
       include Twitter::REST::API
-      BASE_URL = 'https://api.twitter.com'
+      BASE_URL = 'https://api.twitter.com'.freeze
       URL_PREFIX = BASE_URL
       ENDPOINT = BASE_URL
       attr_accessor :bearer_token

--- a/lib/twitter/rest/direct_messages.rb
+++ b/lib/twitter/rest/direct_messages.rb
@@ -128,9 +128,9 @@ module Twitter
         options[:text] = text
         perform_post_with_object('/1.1/direct_messages/new.json', options, Twitter::DirectMessage)
       end
-      alias_method :d, :create_direct_message
-      alias_method :m, :create_direct_message
-      alias_method :dm, :create_direct_message
+      alias d create_direct_message
+      alias m create_direct_message
+      alias dm create_direct_message
       deprecate_alias :direct_message_create, :create_direct_message
     end
   end

--- a/lib/twitter/rest/favorites.rb
+++ b/lib/twitter/rest/favorites.rb
@@ -50,7 +50,7 @@ module Twitter
       def unfavorite(*args)
         parallel_objects_from_response(Twitter::Tweet, :post, '/1.1/favorites/destroy.json', args)
       end
-      alias_method :destroy_favorite, :unfavorite
+      alias destroy_favorite unfavorite
       deprecate_alias :favorite_destroy, :unfavorite
 
       # Favorites the specified Tweets as the authenticating user
@@ -75,8 +75,8 @@ module Twitter
           end
         end.compact
       end
-      alias_method :fav, :favorite
-      alias_method :fave, :favorite
+      alias fav favorite
+      alias fave favorite
       deprecate_alias :favorite_create, :favorite
 
       # Favorites the specified Tweets as the authenticating user and raises an error if one has already been favorited
@@ -99,9 +99,9 @@ module Twitter
           perform_post_with_object('/1.1/favorites/create.json', arguments.options.merge(:id => extract_id(tweet)), Twitter::Tweet)
         end
       end
-      alias_method :create_favorite!, :favorite!
-      alias_method :fav!, :favorite!
-      alias_method :fave!, :favorite!
+      alias create_favorite! favorite!
+      alias fav! favorite!
+      alias fave! favorite!
       deprecate_alias :favorite_create!, :favorite!
     end
   end

--- a/lib/twitter/rest/friends_and_followers.rb
+++ b/lib/twitter/rest/friends_and_followers.rb
@@ -113,7 +113,7 @@ module Twitter
         end
         follow!(new_friends.value - existing_friends.value, arguments.options)
       end
-      alias_method :create_friendship, :follow
+      alias create_friendship follow
       deprecate_alias :friendship_create, :follow
 
       # Allows the authenticating user to follow the specified users
@@ -135,7 +135,7 @@ module Twitter
           perform_post_with_object('/1.1/friendships/create.json', merge_user(arguments.options, user), Twitter::User)
         end.compact
       end
-      alias_method :create_friendship!, :follow!
+      alias create_friendship! follow!
       deprecate_alias :friendship_create!, :follow!
 
       # Allows the authenticating user to unfollow the specified users
@@ -153,7 +153,7 @@ module Twitter
       def unfollow(*args)
         parallel_users_from_response(:post, '/1.1/friendships/destroy.json', args)
       end
-      alias_method :destroy_friendship, :unfollow
+      alias destroy_friendship unfollow
       deprecate_alias :friendship_destroy, :unfollow
 
       # Allows one to enable or disable retweets and device notifications from the specified user.
@@ -189,8 +189,8 @@ module Twitter
         options[:target_id] = options.delete(:target_user_id) unless options[:target_user_id].nil?
         perform_get_with_object('/1.1/friendships/show.json', options, Twitter::Relationship)
       end
-      alias_method :friendship_show, :friendship
-      alias_method :relationship, :friendship
+      alias friendship_show friendship
+      alias relationship friendship
 
       # Test for the existence of friendship between two users
       #
@@ -253,7 +253,7 @@ module Twitter
       def friends(*args)
         cursor_from_response_with_user(:users, Twitter::User, '/1.1/friends/list.json', args)
       end
-      alias_method :following, :friends
+      alias following friends
 
       # Returns a collection of user IDs that the currently authenticated user does not want to receive retweets from.
       # @see https://dev.twitter.com/rest/reference/get/friendships/no_retweets/ids
@@ -265,7 +265,7 @@ module Twitter
       def no_retweet_ids(options = {})
         perform_get('/1.1/friendships/no_retweets/ids.json', options).collect(&:to_i)
       end
-      alias_method :no_retweets_ids, :no_retweet_ids
+      alias no_retweets_ids no_retweet_ids
     end
   end
 end

--- a/lib/twitter/rest/lists.rb
+++ b/lib/twitter/rest/lists.rb
@@ -33,7 +33,7 @@ module Twitter
       def lists(*args)
         objects_from_response_with_user(Twitter::List, :get, '/1.1/lists/list.json', args)
       end
-      alias_method :lists_subscribed_to, :lists
+      alias lists_subscribed_to lists
 
       # Show tweet timeline for members of the specified list
       #

--- a/lib/twitter/rest/lists.rb
+++ b/lib/twitter/rest/lists.rb
@@ -14,7 +14,7 @@ module Twitter
       include Twitter::REST::Utils
       include Twitter::Utils
       MAX_USERS_PER_REQUEST = 100
-      URI_SUBSTRING = '://'
+      URI_SUBSTRING = '://'.freeze
 
       # Returns all lists the authenticating or specified user subscribes to, including their own
       #

--- a/lib/twitter/rest/media.rb
+++ b/lib/twitter/rest/media.rb
@@ -22,7 +22,7 @@ module Twitter
         conn = connection.dup
         conn.url_prefix = base_url
         headers = Twitter::Headers.new(self, :post, base_url + path, options).request_headers
-        options.merge!(:media => media)
+        options[:media] = media
         conn.post(path, options) { |request| request.headers.update(headers) }.env.body[:media_id]
       end
     end

--- a/lib/twitter/rest/oauth.rb
+++ b/lib/twitter/rest/oauth.rb
@@ -28,7 +28,7 @@ module Twitter
         options[:grant_type] ||= 'client_credentials'
         perform_post_with_object('/oauth2/token', options, Twitter::Token)
       end
-      alias_method :bearer_token, :token
+      alias bearer_token token
 
       # Allows a registered application to revoke an issued OAuth 2 Bearer Token by presenting its client credentials.
       #

--- a/lib/twitter/rest/places_and_geo.rb
+++ b/lib/twitter/rest/places_and_geo.rb
@@ -58,7 +58,7 @@ module Twitter
       def geo_search(options = {})
         perform_get_with_object('/1.1/geo/search.json', options, Twitter::GeoResults)
       end
-      alias_method :places_nearby, :geo_search
+      alias places_nearby geo_search
 
       # Locates places near the given coordinates which are similar in name
       #
@@ -77,7 +77,7 @@ module Twitter
       def similar_places(options = {})
         perform_get_with_object('/1.1/geo/similar_places.json', options, Twitter::GeoResults)
       end
-      alias_method :places_similar, :similar_places
+      alias places_similar similar_places
     end
   end
 end

--- a/lib/twitter/rest/request.rb
+++ b/lib/twitter/rest/request.rb
@@ -11,7 +11,7 @@ module Twitter
     class Request
       attr_accessor :client, :headers, :options, :rate_limit, :request_method,
                     :path, :uri
-      alias_method :verb, :request_method
+      alias verb request_method
 
       # @param client [Twitter::Client]
       # @param request_method [String, Symbol]

--- a/lib/twitter/rest/request/multipart_with_file.rb
+++ b/lib/twitter/rest/request/multipart_with_file.rb
@@ -4,7 +4,7 @@ module Twitter
   module REST
     class Request
       class MultipartWithFile < Faraday::Middleware
-        CONTENT_TYPE = 'Content-Type'
+        CONTENT_TYPE = 'Content-Type'.freeze
         BMP_REGEX = /\.bmp/i
         GIF_REGEX = /\.gif$/i
         JPEG_REGEX = /\.jpe?g/i

--- a/lib/twitter/rest/timelines.rb
+++ b/lib/twitter/rest/timelines.rb
@@ -25,7 +25,7 @@ module Twitter
       def mentions_timeline(options = {})
         perform_get_with_objects('/1.1/statuses/mentions_timeline.json', options, Twitter::Tweet)
       end
-      alias_method :mentions, :mentions_timeline
+      alias mentions mentions_timeline
 
       # Returns the 20 most recent Tweets posted by the specified user
       #
@@ -70,7 +70,7 @@ module Twitter
           user_timeline(user, opts)
         end
       end
-      alias_method :retweeted_by, :retweeted_by_user
+      alias retweeted_by retweeted_by_user
 
       # Returns the 20 most recent retweets posted by the authenticating user
       #

--- a/lib/twitter/rest/trends.rb
+++ b/lib/twitter/rest/trends.rb
@@ -23,8 +23,8 @@ module Twitter
         response = perform_get('/1.1/trends/place.json', options).first
         Twitter::TrendResults.new(response)
       end
-      alias_method :local_trends, :trends
-      alias_method :trends_place, :trends
+      alias local_trends trends
+      alias trends_place trends
 
       # Returns the locations that Twitter has trending topic information for
       #
@@ -37,7 +37,7 @@ module Twitter
       def trends_available(options = {})
         perform_get_with_objects('/1.1/trends/available.json', options, Twitter::Place)
       end
-      alias_method :trend_locations, :trends_available
+      alias trend_locations trends_available
 
       # Returns the locations that Twitter has trending topic information for, closest to a specified location.
       #

--- a/lib/twitter/rest/trends.rb
+++ b/lib/twitter/rest/trends.rb
@@ -8,7 +8,7 @@ module Twitter
     module Trends
       include Twitter::REST::Utils
 
-      # Returns the top 10 trending topics for a specific WOEID
+      # Returns the top 50 trending topics for a specific WOEID
       #
       # @see https://dev.twitter.com/rest/reference/get/trends/place
       # @rate_limited Yes

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -100,7 +100,7 @@ module Twitter
           perform_post_with_object("/1.1/statuses/destroy/#{extract_id(tweet)}.json", arguments.options, Twitter::Tweet)
         end
       end
-      alias_method :destroy_tweet, :destroy_status
+      alias destroy_tweet destroy_status
       deprecate_alias :status_destroy, :destroy_status
       deprecate_alias :tweet_destroy, :destroy_status
 

--- a/lib/twitter/rest/users.rb
+++ b/lib/twitter/rest/users.rb
@@ -50,7 +50,7 @@ module Twitter
       def verify_credentials(options = {})
         perform_get_with_object('/1.1/account/verify_credentials.json', options, Twitter::User)
       end
-      alias_method :current_user, :verify_credentials
+      alias current_user verify_credentials
 
       # Sets which device Twitter delivers updates to for the authenticating user
       #

--- a/lib/twitter/rest/utils.rb
+++ b/lib/twitter/rest/utils.rb
@@ -232,7 +232,7 @@ module Twitter
         hash
       end
 
-      def collect_user_ids_and_screen_names(users) # rubocop:disable MethodLength
+      def collect_user_ids_and_screen_names(users)
         user_ids = []
         screen_names = []
         users.flatten.each do |user|
@@ -240,11 +240,7 @@ module Twitter
           when Integer
             user_ids << user
           when String
-            if user[URI_SUBSTRING]
-              screen_names << user.split('/').last
-            else
-              screen_names << user
-            end
+            screen_names << (user[URI_SUBSTRING] ? user.split('/').last : user)
           when URI
             screen_names << user.path.split('/').last
           when Twitter::User

--- a/lib/twitter/rest/utils.rb
+++ b/lib/twitter/rest/utils.rb
@@ -9,7 +9,7 @@ module Twitter
   module REST
     module Utils
       include Twitter::Utils
-      URI_SUBSTRING = '://'
+      URI_SUBSTRING = '://'.freeze
       DEFAULT_CURSOR = -1
 
     private

--- a/lib/twitter/search_results.rb
+++ b/lib/twitter/search_results.rb
@@ -10,8 +10,8 @@ module Twitter
     include Twitter::Utils
     # @return [Hash]
     attr_reader :attrs
-    alias_method :to_h, :attrs
-    alias_method :to_hash, :to_h
+    alias to_h attrs
+    alias to_hash to_h
     deprecate_alias :to_hsh, :to_hash
 
     # Initializes a new SearchResults object

--- a/lib/twitter/settings.rb
+++ b/lib/twitter/settings.rb
@@ -7,9 +7,16 @@ module Twitter
     # @return [String]
     attr_reader :language, :screen_name
     object_attr_reader :Place, :trend_location
-    predicate_attr_reader :always_use_https, :discoverable_by_email,
+    predicate_attr_reader :allow_contributor_request,
+                          :allow_dm_groups_from,
+                          :allow_dms_from,
+                          :always_use_https,
+                          :discoverable_by_email,
                           :discoverable_by_mobile_phone,
-                          :display_sensitive_media, :geo_enabled, :protected,
-                          :show_all_inline_media, :use_cookie_personalization
+                          :display_sensitive_media,
+                          :geo_enabled,
+                          :protected,
+                          :show_all_inline_media,
+                          :use_cookie_personalization
   end
 end

--- a/lib/twitter/size.rb
+++ b/lib/twitter/size.rb
@@ -8,7 +8,7 @@ module Twitter
     attr_reader :h, :w
     # @return [String]
     attr_reader :resize
-    alias_method :height, :h
-    alias_method :width, :w
+    alias height h
+    alias width w
   end
 end

--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -110,7 +110,7 @@ module Twitter
         before_request.call
         authorization = Twitter::Headers.new(self, method, uri, params).oauth_auth_header.to_s
         headers = default_headers.merge(:authorization => authorization)
-        request = HTTP::Request.new(method, uri + '?' + to_url_params(params), headers)
+        request = HTTP::Request.new(:verb => method, :uri => uri + '?' + to_url_params(params), :headers => headers)
         response = Streaming::Response.new do |data|
           if item = Streaming::MessageParser.parse(data) # rubocop:disable AssignmentInCondition
             yield(item)

--- a/lib/twitter/streaming/connection.rb
+++ b/lib/twitter/streaming/connection.rb
@@ -13,7 +13,7 @@ module Twitter
 
       def stream(request, response)
         client_context = OpenSSL::SSL::SSLContext.new
-        client         = @tcp_socket_class.new(Resolv.getaddress(request.uri.host), request.uri.port)
+        client         = @tcp_socket_class.new(Resolv.getaddress(request.socket_host), request.socket_port)
         ssl_client     = @ssl_socket_class.new(client, client_context)
 
         ssl_client.connect

--- a/lib/twitter/streaming/event.rb
+++ b/lib/twitter/streaming/event.rb
@@ -5,11 +5,11 @@ module Twitter
         :list_created, :list_destroyed, :list_updated, :list_member_added,
         :list_member_added, :list_member_removed, :list_user_subscribed,
         :list_user_subscribed, :list_user_unsubscribed, :list_user_unsubscribed
-      ]
+      ].freeze
 
       TWEET_EVENTS = [
         :favorite, :unfavorite
-      ]
+      ].freeze
 
       attr_reader :name, :source, :target, :target_object
 

--- a/lib/twitter/token.rb
+++ b/lib/twitter/token.rb
@@ -7,7 +7,7 @@ module Twitter
 
     # @return [String]
     attr_reader :access_token, :token_type
-    alias_method :to_s, :access_token
+    alias to_s access_token
 
     BEARER_TYPE = 'bearer'
 

--- a/lib/twitter/token.rb
+++ b/lib/twitter/token.rb
@@ -9,7 +9,7 @@ module Twitter
     attr_reader :access_token, :token_type
     alias to_s access_token
 
-    BEARER_TYPE = 'bearer'
+    BEARER_TYPE = 'bearer'.freeze
 
     # @return [Boolean]
     def bearer?

--- a/lib/twitter/trend.rb
+++ b/lib/twitter/trend.rb
@@ -5,7 +5,7 @@ module Twitter
   class Trend < Twitter::Base
     include Equalizer.new(:name)
     # @return [String]
-    attr_reader :events, :name, :query
+    attr_reader :events, :name, :query, :tweet_volume
     predicate_attr_reader :promoted_content
     uri_attr_reader :uri
   end

--- a/lib/twitter/trend_results.rb
+++ b/lib/twitter/trend_results.rb
@@ -12,8 +12,8 @@ module Twitter
     include Memoizable
     # @return [Hash]
     attr_reader :attrs
-    alias_method :to_h, :attrs
-    alias_method :to_hash, :to_h
+    alias to_h attrs
+    alias to_hash to_h
     deprecate_alias :to_hsh, :to_hash
 
     # Initializes a new TrendResults object

--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -13,20 +13,20 @@ module Twitter
                 :retweet_count
     deprecate_alias :favorites_count, :favorite_count
     deprecate_alias :favoriters_count, :favorite_count
-    alias_method :in_reply_to_tweet_id, :in_reply_to_status_id
-    alias_method :reply?, :in_reply_to_user_id?
+    alias in_reply_to_tweet_id in_reply_to_status_id
+    alias reply? in_reply_to_user_id?
     deprecate_alias :retweeters_count, :retweet_count
     object_attr_reader :GeoFactory, :geo
     object_attr_reader :Metadata, :metadata
     object_attr_reader :Place, :place
     object_attr_reader :Tweet, :retweeted_status
     object_attr_reader :Tweet, :quoted_status
-    alias_method :retweeted_tweet, :retweeted_status
-    alias_method :retweet?, :retweeted_status?
-    alias_method :retweeted_tweet?, :retweeted_status?
-    alias_method :quoted_tweet, :quoted_status
-    alias_method :quote?, :quoted_status?
-    alias_method :quoted_tweet?, :quoted_status?
+    alias retweeted_tweet retweeted_status
+    alias retweet? retweeted_status?
+    alias retweeted_tweet? retweeted_status?
+    alias quoted_tweet quoted_status
+    alias quote? quoted_status?
+    alias quoted_tweet? quoted_status?
     object_attr_reader :User, :user, :status
     predicate_attr_reader :favorited, :possibly_sensitive, :retweeted,
                           :truncated
@@ -48,7 +48,7 @@ module Twitter
       Addressable::URI.parse("https://twitter.com/#{user.screen_name}/status/#{id}") if user?
     end
     memoize :uri
-    alias_method :url, :uri
+    alias url uri
   end
   Status = Tweet
 end

--- a/lib/twitter/user.rb
+++ b/lib/twitter/user.rb
@@ -16,7 +16,7 @@ module Twitter
     attr_reader :favourites_count, :followers_count, :friends_count,
                 :listed_count, :statuses_count, :utc_offset
     # @return [String]
-    attr_reader :description, :lang, :location, :name,
+    attr_reader :description, :lang, :location, :name, :email,
                 :profile_background_color, :profile_link_color,
                 :profile_sidebar_border_color, :profile_sidebar_fill_color,
                 :profile_text_color, :time_zone

--- a/lib/twitter/user.rb
+++ b/lib/twitter/user.rb
@@ -20,12 +20,12 @@ module Twitter
                 :profile_background_color, :profile_link_color,
                 :profile_sidebar_border_color, :profile_sidebar_fill_color,
                 :profile_text_color, :time_zone
-    alias_method :favorites_count, :favourites_count
-    alias_method :tweets_count, :statuses_count
+    alias favorites_count favourites_count
+    alias tweets_count statuses_count
     object_attr_reader :Tweet, :status, :user
-    alias_method :tweet, :status
-    alias_method :tweet?, :status?
-    alias_method :tweeted?, :status?
+    alias tweet status
+    alias tweet? status?
+    alias tweeted? status?
     predicate_attr_reader :contributors_enabled, :default_profile,
                           :default_profile_image, :follow_request_sent,
                           :geo_enabled, :muting, :needs_phone_verification,
@@ -84,7 +84,7 @@ module Twitter
       Addressable::URI.parse("https://twitter.com/#{screen_name}") if screen_name?
     end
     memoize :uri
-    alias_method :url, :uri
+    alias url uri
 
     # @return [Addressable::URI] The URL to the user's website.
     def website

--- a/lib/twitter/version.rb
+++ b/lib/twitter/version.rb
@@ -9,7 +9,7 @@ module Twitter
 
     # @return [Integer]
     def minor
-      15
+      16
     end
 
     # @return [Integer]

--- a/lib/twitter/version.rb
+++ b/lib/twitter/version.rb
@@ -9,7 +9,7 @@ module Twitter
 
     # @return [Integer]
     def minor
-      14
+      15
     end
 
     # @return [Integer]

--- a/lib/twitter/version.rb
+++ b/lib/twitter/version.rb
@@ -34,7 +34,7 @@ module Twitter
 
     # @return [Array]
     def to_a
-      to_h.values.compact
+      [major, minor, patch, pre].compact
     end
 
     # @return [String]

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -170,7 +170,7 @@ describe Twitter::Tweet do
   describe '#hashtags?' do
     it 'returns true when the tweet includes hashtags entities' do
       entities = {
-        :hashtags => [{:text => 'twitter', :indices => [10, 33]}],
+        :hashtags => [{:text => 'twitter', :indices => [10, 33]}]
       }
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.hashtags?).to be true
@@ -196,7 +196,7 @@ describe Twitter::Tweet do
   describe '#media?' do
     it 'returns true when the tweet includes media entities' do
       entities = {
-        :media => [{:id => '1', :type => 'photo'}],
+        :media => [{:id => '1', :type => 'photo'}]
       }
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.media?).to be true
@@ -352,7 +352,7 @@ describe Twitter::Tweet do
   describe '#symbols?' do
     it 'returns true when the tweet includes symbols entities' do
       entities = {
-        :symbols => [{:text => 'PEP'}],
+        :symbols => [{:text => 'PEP'}]
       }
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.symbols?).to be true
@@ -412,7 +412,7 @@ describe Twitter::Tweet do
   describe '#uris?' do
     it 'returns true when the tweet includes urls entities' do
       entities = {
-        :urls => [{:url => 'https://t.co/L2xIBazMPf'}],
+        :urls => [{:url => 'https://t.co/L2xIBazMPf'}]
       }
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.uris?).to be true
@@ -476,7 +476,7 @@ describe Twitter::Tweet do
   describe '#user_mentions?' do
     it 'returns true when the tweet includes user_mention entities' do
       entities = {
-        :user_mentions => [{:screen_name => 'sferik'}],
+        :user_mentions => [{:screen_name => 'sferik'}]
       }
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.user_mentions?).to be true

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -169,9 +169,7 @@ describe Twitter::Tweet do
 
   describe '#hashtags?' do
     it 'returns true when the tweet includes hashtags entities' do
-      entities = {
-        :hashtags => [{:text => 'twitter', :indices => [10, 33]}]
-      }
+      entities = {:hashtags => [{:text => 'twitter', :indices => [10, 33]}]}
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.hashtags?).to be true
     end
@@ -195,9 +193,7 @@ describe Twitter::Tweet do
 
   describe '#media?' do
     it 'returns true when the tweet includes media entities' do
-      entities = {
-        :media => [{:id => '1', :type => 'photo'}]
-      }
+      entities = {:media => [{:id => '1', :type => 'photo'}]}
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.media?).to be true
     end
@@ -351,9 +347,7 @@ describe Twitter::Tweet do
 
   describe '#symbols?' do
     it 'returns true when the tweet includes symbols entities' do
-      entities = {
-        :symbols => [{:text => 'PEP'}]
-      }
+      entities = {:symbols => [{:text => 'PEP'}]}
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.symbols?).to be true
     end
@@ -411,9 +405,7 @@ describe Twitter::Tweet do
 
   describe '#uris?' do
     it 'returns true when the tweet includes urls entities' do
-      entities = {
-        :urls => [{:url => 'https://t.co/L2xIBazMPf'}]
-      }
+      entities = {:urls => [{:url => 'https://t.co/L2xIBazMPf'}]}
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.uris?).to be true
     end
@@ -475,9 +467,7 @@ describe Twitter::Tweet do
 
   describe '#user_mentions?' do
     it 'returns true when the tweet includes user_mention entities' do
-      entities = {
-        :user_mentions => [{:screen_name => 'sferik'}]
-      }
+      entities = {:user_mentions => [{:screen_name => 'sferik'}]}
       tweet = Twitter::Tweet.new(:id => 28_669_546_014, :entities => entities)
       expect(tweet.user_mentions?).to be true
     end

--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'buftok', '~> 0.2.0'
   spec.add_dependency 'equalizer', '0.0.10'
   spec.add_dependency 'faraday', '~> 0.9.0'
-  spec.add_dependency 'http', ['>= 0.4', '< 0.10']
+  spec.add_dependency 'http', '~> 1.0'
   spec.add_dependency 'http_parser.rb', '~> 0.6.0'
   spec.add_dependency 'json', '~> 1.8'
   spec.add_dependency 'memoizable', '~> 0.4.0'


### PR DESCRIPTION
User emails are now provided, upon request, from the account/verify_credentials.json endpoint. This requires asking the user for permission during authorization and passing `include_email: true` to the `verify_credentials` method.

https://dev.twitter.com/rest/reference/get/account/verify_credentials