### PR TITLE
Add email attribute to User

### DIFF
--- a/lib/twitter/user.rb
+++ b/lib/twitter/user.rb
@@ -16,7 +16,7 @@ module Twitter
     attr_reader :favourites_count, :followers_count, :friends_count,
                 :listed_count, :statuses_count, :utc_offset
     # @return [String]
-    attr_reader :description, :lang, :location, :name,
+    attr_reader :description, :lang, :location, :name, :email,
                 :profile_background_color, :profile_link_color,
                 :profile_sidebar_border_color, :profile_sidebar_fill_color,
                 :profile_text_color, :time_zone


### PR DESCRIPTION
User emails are now provided, upon request, from the account/verify_credentials.json endpoint. This requires asking the user for permission during authorization and passing include_email: true to the verify_credentials method.

https://dev.twitter.com/rest/reference/get/account/verify_credentials
