### PR TITLE
Dump Twitter::NullObject as JSON properly

### DIFF
--- a/lib/twitter/null_object.rb
+++ b/lib/twitter/null_object.rb
@@ -48,5 +48,9 @@ module Twitter
     def as_json(*)
       'null'
     end
+
+    def to_json(*args)
+      nil.to_json(*args)
+    end
   end
 end

--- a/spec/twitter/null_object_spec.rb
+++ b/spec/twitter/null_object_spec.rb
@@ -66,6 +66,12 @@ describe Twitter::NullObject do
     end
   end
 
+  describe '#to_json' do
+    it 'returns JSON' do
+      expect({ "null_object" => subject }.to_json).to eq(%Q({"null_object":null}))
+    end
+  end
+
   describe 'black hole' do
     it 'returns self for missing methods' do
       expect(subject.missing).to eq(subject)

--- a/spec/twitter/null_object_spec.rb
+++ b/spec/twitter/null_object_spec.rb
@@ -68,7 +68,7 @@ describe Twitter::NullObject do
 
   describe '#to_json' do
     it 'returns JSON' do
-      expect({ "null_object" => subject }.to_json).to eq(%Q({"null_object":null}))
+      expect({'null_object' => subject}.to_json).to eq('{"null_object":null}')
     end
   end
 


### PR DESCRIPTION
```
null = Twitter::NullOjbect.new
{ "null_object" => null }.to_json
```

In previous version, above code raises a TypeError:

    TypeError: wrong argument type Twitter::NullObject (expected String)