### PR TITLE
Use http's timeout api

### DIFF
--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -5,7 +5,7 @@ require 'twitter/version'
 module Twitter
   class Client
     include Twitter::Utils
-    attr_accessor :access_token, :access_token_secret, :consumer_key, :consumer_secret, :proxy
+    attr_accessor :access_token, :access_token_secret, :consumer_key, :consumer_secret, :proxy, :timeouts
     attr_writer :user_agent
 
     # Initializes a new Client object

--- a/lib/twitter/rest/request.rb
+++ b/lib/twitter/rest/request.rb
@@ -118,12 +118,15 @@ module Twitter
       # @return [HTTP::Client, HTTP]
       def http_client
         client = @client.proxy ? HTTP.via(*proxy) : HTTP
-        client = client.timeout(
-          :per_operation,
-          connect: @client.timeouts[:connect],
-          read: @client.timeouts[:read],
-          write: @client.timeouts[:write]
-        ) if @client.timeouts
+
+        if @client.timeouts
+          client = client.timeout(
+            :per_operation,
+            connect: @client.timeouts[:connect],
+            read: @client.timeouts[:read],
+            write: @client.timeouts[:write]
+          )
+        end
 
         client
       end

--- a/lib/twitter/rest/request.rb
+++ b/lib/twitter/rest/request.rb
@@ -117,7 +117,15 @@ module Twitter
 
       # @return [HTTP::Client, HTTP]
       def http_client
-        @client.proxy ? HTTP.via(*proxy) : HTTP
+        client = @client.proxy ? HTTP.via(*proxy) : HTTP
+        client = client.timeout(
+          :per_operation,
+          connect: @client.timeouts[:connect],
+          read: @client.timeouts[:read],
+          write: @client.timeouts[:write]
+        ) if @client.timeouts
+
+        client
       end
 
       # Return proxy values as a compacted array

--- a/spec/twitter/rest/request_spec.rb
+++ b/spec/twitter/rest/request_spec.rb
@@ -34,6 +34,28 @@ describe Twitter::REST::Request do
         expect(HTTP).to receive(:via).with('127.0.0.1', 3328).twice.and_call_original
         @client.update_with_media('Update', fixture('pbjt.gif'))
       end
+
+      context 'when using timeout options' do
+        before do
+          @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS', proxy: {host: '127.0.0.1', port: 3328}, timeouts: { connect: 2, read: 2, write: 3 })
+        end
+        it 'requests with given timeout settings' do
+          stub_post('/1.1/statuses/update.json').with(body: {status: 'Update'}).to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
+          expect_any_instance_of(HTTP::Client).to receive(:timeout).with(:per_operation, connect: 2, read: 2, write: 3).and_call_original
+          @client.update('Update')
+        end
+      end
+    end
+
+    context 'when using timeout options' do
+      before do
+        @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS', timeouts: { connect: 2, read: 2, write: 3 })
+      end
+      it 'requests with given timeout settings' do
+        stub_post('/1.1/statuses/update.json').with(body: {status: 'Update'}).to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        expect(HTTP).to receive(:timeout).with(:per_operation, connect: 2, read: 2, write: 3).and_call_original
+        @client.update('Update')
+      end
     end
   end
 end

--- a/spec/twitter/rest/request_spec.rb
+++ b/spec/twitter/rest/request_spec.rb
@@ -37,7 +37,7 @@ describe Twitter::REST::Request do
 
       context 'when using timeout options' do
         before do
-          @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS', proxy: {host: '127.0.0.1', port: 3328}, timeouts: { connect: 2, read: 2, write: 3 })
+          @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS', proxy: {host: '127.0.0.1', port: 3328}, timeouts: {connect: 2, read: 2, write: 3})
         end
         it 'requests with given timeout settings' do
           stub_post('/1.1/statuses/update.json').with(body: {status: 'Update'}).to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
@@ -49,7 +49,7 @@ describe Twitter::REST::Request do
 
     context 'when using timeout options' do
       before do
-        @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS', timeouts: { connect: 2, read: 2, write: 3 })
+        @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS', timeouts: {connect: 2, read: 2, write: 3})
       end
       it 'requests with given timeout settings' do
         stub_post('/1.1/statuses/update.json').with(body: {status: 'Update'}).to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})


### PR DESCRIPTION
Currently twitter gem users can not set a timeout for requests which could lead to stuck requests.

This fixes #791.