### PR TITLE
Support ActiveSupport 'presence' methods on Twitter::NullObject

### DIFF
--- a/lib/twitter/null_object.rb
+++ b/lib/twitter/null_object.rb
@@ -48,5 +48,17 @@ module Twitter
     def to_json(*args)
       nil.to_json(*args)
     end
+
+    def presence
+      nil
+    end
+
+    def blank?
+      true
+    end
+
+    def present?
+      false
+    end
   end
 end

--- a/spec/twitter/null_object_spec.rb
+++ b/spec/twitter/null_object_spec.rb
@@ -109,4 +109,22 @@ describe Twitter::NullObject do
       expect(subject).not_to be_missing
     end
   end
+
+  describe '#presence' do
+    it 'returns nil' do
+      expect(subject.presence).to eq nil
+    end
+  end
+
+  describe '#blank?' do
+    it 'returns true' do
+      expect(subject.blank?).to eq true
+    end
+  end
+
+  describe '#present?' do
+    it 'returns false' do
+      expect(subject.present?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
This makes consumption of the Twitter::NullObject easier in Rails projects.

Adds the following methods to Twitter::NullObject:

1. #presence
2. #present?
3. #blank?

This is a follow up to https://github.com/sferik/twitter/pull/764 with the requested changes.