### PR TITLE
Change REST users/lookup endpoint from POST to GET as per Twitter docs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 Metrics/BlockLength:
   Max: 36
+  Exclude:
+    - "**/*_spec.rb"
+    - "**/*_examples.rb"
 
 Metrics/BlockNesting:
   Max: 2
@@ -14,6 +17,9 @@ Metrics/MethodLength:
 
 Metrics/ModuleLength:
   Max: 150 # TODO: Lower to 100
+  Exclude:
+    - "**/*_spec.rb"
+    - "**/*_examples.rb"
 
 Metrics/ParameterLists:
   Max: 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ sudo: false
 
 bundler_args: --without development --retry=3 --jobs=3
 
+before_install:
+  - gem update --remote bundler
+  - gem update --system
+  - rvm @global do gem uninstall bundler -a -x
+  - rvm @global do gem install bundler -v 1.13.7
+
 env:
   global:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"

--- a/lib/twitter/rest/users.rb
+++ b/lib/twitter/rest/users.rb
@@ -208,7 +208,7 @@ module Twitter
       def users(*args)
         arguments = Twitter::Arguments.new(args)
         flat_pmap(arguments.each_slice(MAX_USERS_PER_REQUEST)) do |users|
-          perform_post_with_objects('/1.1/users/lookup.json', merge_users(arguments.options, users), Twitter::User)
+          perform_get_with_objects('/1.1/users/lookup.json', merge_users(arguments.options, users), Twitter::User)
         end
       end
 

--- a/spec/twitter/rest/friends_and_followers_spec.rb
+++ b/spec/twitter/rest/friends_and_followers_spec.rb
@@ -295,14 +295,14 @@ describe Twitter::REST::FriendsAndFollowers do
     before do
       stub_get('/1.1/account/verify_credentials.json').with(query: {skip_status: 'true'}).to_return(body: fixture('sferik.json'), headers: {content_type: 'application/json; charset=utf-8'})
       stub_get('/1.1/friends/ids.json').with(query: {user_id: '7505382', cursor: '-1'}).to_return(body: fixture('ids_list2.json'), headers: {content_type: 'application/json; charset=utf-8'})
-      stub_post('/1.1/users/lookup.json').with(body: {screen_name: 'sferik,pengwynn'}).to_return(body: fixture('friendships.json'), headers: {content_type: 'application/json; charset=utf-8'})
+      stub_get('/1.1/users/lookup.json').with(query: {screen_name: 'sferik,pengwynn'}).to_return(body: fixture('friendships.json'), headers: {content_type: 'application/json; charset=utf-8'})
       stub_post('/1.1/friendships/create.json').with(body: {user_id: '7505382'}).to_return(body: fixture('sferik.json'), headers: {content_type: 'application/json; charset=utf-8'})
     end
     it 'requests the correct resource' do
       @client.follow('sferik', 'pengwynn')
       expect(a_get('/1.1/account/verify_credentials.json').with(query: {skip_status: 'true'})).to have_been_made
       expect(a_get('/1.1/friends/ids.json').with(query: {user_id: '7505382', cursor: '-1'})).to have_been_made
-      expect(a_post('/1.1/users/lookup.json').with(body: {screen_name: 'sferik,pengwynn'})).to have_been_made
+      expect(a_get('/1.1/users/lookup.json').with(query: {screen_name: 'sferik,pengwynn'})).to have_been_made
       expect(a_post('/1.1/friendships/create.json').with(body: {user_id: '7505382'})).to have_been_made
     end
   end

--- a/spec/twitter/rest/users_spec.rb
+++ b/spec/twitter/rest/users_spec.rb
@@ -289,11 +289,11 @@ describe Twitter::REST::Users do
   describe '#users' do
     context 'with screen names passed' do
       before do
-        stub_post('/1.1/users/lookup.json').with(body: {screen_name: 'sferik,pengwynn'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_get('/1.1/users/lookup.json').with(query: {screen_name: 'sferik,pengwynn'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'requests the correct resource' do
         @client.users('sferik', 'pengwynn')
-        expect(a_post('/1.1/users/lookup.json').with(body: {screen_name: 'sferik,pengwynn'})).to have_been_made
+        expect(a_get('/1.1/users/lookup.json').with(query: {screen_name: 'sferik,pengwynn'})).to have_been_made
       end
       it 'returns up to 100 users worth of extended information' do
         users = @client.users('sferik', 'pengwynn')
@@ -306,46 +306,46 @@ describe Twitter::REST::Users do
           sferik = URI.parse('https://twitter.com/sferik')
           pengwynn = URI.parse('https://twitter.com/pengwynn')
           @client.users(sferik, pengwynn)
-          expect(a_post('/1.1/users/lookup.json').with(body: {screen_name: 'sferik,pengwynn'})).to have_been_made
+          expect(a_get('/1.1/users/lookup.json').with(query: {screen_name: 'sferik,pengwynn'})).to have_been_made
         end
       end
     end
     context 'with numeric screen names passed' do
       before do
-        stub_post('/1.1/users/lookup.json').with(body: {screen_name: '0,311'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_get('/1.1/users/lookup.json').with(query: {screen_name: '0,311'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'requests the correct resource' do
         @client.users('0', '311')
-        expect(a_post('/1.1/users/lookup.json').with(body: {screen_name: '0,311'})).to have_been_made
+        expect(a_get('/1.1/users/lookup.json').with(query: {screen_name: '0,311'})).to have_been_made
       end
     end
     context 'with user IDs passed' do
       before do
-        stub_post('/1.1/users/lookup.json').with(body: {user_id: '7505382,14100886'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_get('/1.1/users/lookup.json').with(query: {user_id: '7505382,14100886'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'requests the correct resource' do
         @client.users(7_505_382, 14_100_886)
-        expect(a_post('/1.1/users/lookup.json').with(body: {user_id: '7505382,14100886'})).to have_been_made
+        expect(a_get('/1.1/users/lookup.json').with(query: {user_id: '7505382,14100886'})).to have_been_made
       end
     end
     context 'with both screen names and user IDs passed' do
       before do
-        stub_post('/1.1/users/lookup.json').with(body: {screen_name: 'sferik', user_id: '14100886'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_get('/1.1/users/lookup.json').with(query: {screen_name: 'sferik', user_id: '14100886'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'requests the correct resource' do
         @client.users('sferik', 14_100_886)
-        expect(a_post('/1.1/users/lookup.json').with(body: {screen_name: 'sferik', user_id: '14100886'})).to have_been_made
+        expect(a_get('/1.1/users/lookup.json').with(query: {screen_name: 'sferik', user_id: '14100886'})).to have_been_made
       end
     end
     context 'with user objects passed' do
       before do
-        stub_post('/1.1/users/lookup.json').with(body: {user_id: '7505382,14100886'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_get('/1.1/users/lookup.json').with(query: {user_id: '7505382,14100886'}).to_return(body: fixture('users.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'requests the correct resource' do
         user1 = Twitter::User.new(id: 7_505_382)
         user2 = Twitter::User.new(id: 14_100_886)
         @client.users(user1, user2)
-        expect(a_post('/1.1/users/lookup.json').with(body: {user_id: '7505382,14100886'})).to have_been_made
+        expect(a_get('/1.1/users/lookup.json').with(query: {user_id: '7505382,14100886'})).to have_been_made
       end
     end
   end


### PR DESCRIPTION
I ran into an issue with this because my application is currently write-restricted and I was surprised that I was not able to lookup users. The Twitter docs specify this as a GET endpoint, not POST.

This could also cause problems for applications that do not have write privileges at all, changing this to a GET instead of a POST enables them to lookup users.