### PR TITLE
Enable client configuration using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ client = Twitter::REST::Client.new do |config|
 end
 ```
 
+Alternatively, you can set configuration options in environment variables.
+If configuration options were present in both environment variables and
+option blocks (above), options set in the block will be applied.
+
+```bash
+$ export CONSUMER_KEY=YOUR_CONSUMER_KEY
+$ export CONSUMER_SECRET=YOUR_CONSUMER_SECRET
+$ export ACCESS_TOKEN=YOUR_ACCESS_TOKEN
+$ export ACCESS_TOKEN_SECRET=YOUR_ACCESS_TOKEN_SECRET
+```
+
 ## Usage Examples
 After configuring a `client`, you can do the following things.
 

--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -13,6 +13,7 @@ module Twitter
     # @param options [Hash]
     # @return [Twitter::Client]
     def initialize(options = {})
+      set_config_from_env
       options.each do |key, value|
         instance_variable_set("@#{key}", value)
       end
@@ -48,6 +49,18 @@ module Twitter
 
     def blank?(s)
       s.respond_to?(:empty?) ? s.empty? : !s
+    end
+
+    # Sets instance variables from environment variables
+    def set_config_from_env
+      env_keys.each do |key|
+        instance_variable_set("@#{key}", ENV[key.upcase])
+      end
+    end
+
+    # List of keys readable from environment variables
+    def env_keys
+      %w(consumer_key consumer_secret access_token access_token_secret)
     end
   end
 end

--- a/spec/twitter/client_spec.rb
+++ b/spec/twitter/client_spec.rb
@@ -33,9 +33,17 @@ describe Twitter::Client do
   end
 
   describe '#credentials?' do
-    it 'returns true if all credentials are present' do
+    it 'returns true if all credentials are present in arguments' do
       client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS')
       expect(client.credentials?).to be true
+    end
+    it 'returns true if all credentials are present in environment variabes' do
+      original = ENV.to_hash
+      vars = {CONSUMER_KEY: 'CK', CONSUMER_SECRET: 'CS', ACCESS_TOKEN: 'AT', ACCESS_TOKEN_SECRET: 'AS'}
+      vars.each { |k, v| ENV[k.to_s] = v }
+      client = Twitter::REST::Client.new
+      expect(client.credentials?).to be true
+      ENV.replace(original)
     end
     it 'returns false if any credentials are missing' do
       client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT')


### PR DESCRIPTION
This PR will make it possible (again) to configure clients through environment variables. I understand this feature was implemented in `3.0.0`, but then removed in `5.0.0`. I couldn't find discussions/conversations made when it was removed, so anyone who is aware of the circumstances of that time, please kindly let me know. I will close this PR when I felt unnecessary.

```bash
$ export CONSUMER_KEY=YOUR_CONSUMER_KEY
$ export CONSUMER_SECRET=YOUR_CONSUMER_SECRET
$ export ACCESS_TOKEN=YOUR_ACCESS_TOKEN
$ export ACCESS_TOKEN_SECRET=YOUR_ACCESS_TOKEN_SECRET
```

After settings like above, you can use the client without configuration (if configurations were present at the initialization, it will override the environment variables):

```ruby
client = Twitter::REST::Client.new
client.credentials? # returns true
```

I hope this feature will help developers bothering to omit credential information out from their source code. Similar feature is available in other gems, such as [aws-sdk](https://github.com/aws/aws-sdk-ruby#configuration-options).