### PR TITLE
Support closing stream

### DIFF
--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -105,6 +105,10 @@ module Twitter
         end
       end
 
+      def close
+        @connection.close
+      end
+
     private
 
       def request(method, uri, params)


### PR DESCRIPTION
In this version, we can close stream as following:

```ruby
client = Twitter::Streaming::Client.new do |config|
  # Set up configuration
end

t = Thread.new do
  client.filter(track: keyword) do |object|
    # process object
  end
end

Signal.trap(:TERM) do
  # terminate process silently
  client.close
  exit true
end

t.join
```