### PR TITLE
run rubocop autocorrect, add vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ doc/*
 log/*
 measurement/*
 pkg/*
+vendor/

--- a/Rakefile
+++ b/Rakefile
@@ -28,4 +28,4 @@ Yardstick::Rake::Verify.new do |verify|
   verify.threshold = 59.0
 end
 
-task default: [:spec, :rubocop, :verify_measurements]
+task default: %i[spec rubocop verify_measurements]

--- a/lib/twitter/profile.rb
+++ b/lib/twitter/profile.rb
@@ -11,7 +11,7 @@ module Twitter
     private
 
       def alias_predicate_uri_methods(method)
-        %w(_url? _uri_https? _url_https?).each do |replacement|
+        %w[_url? _uri_https? _url_https?].each do |replacement|
           alias_method_sub(method, PREDICATE_URI_METHOD_REGEX, replacement)
         end
       end

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -328,7 +328,7 @@ module Twitter
       #
       # @see https://dev.twitter.com/rest/public/uploading-media
       def upload(media) # rubocop:disable MethodLength, AbcSize
-        if !(File.basename(media) =~ /\.mp4$/)
+        if File.basename(media) !~ /\.mp4$/
           Twitter::REST::Request.new(self, :multipart_post, 'https://upload.twitter.com/1.1/media/upload.json', key: :media, file: media).perform
         else
           init = Twitter::REST::Request.new(self, :post, 'https://upload.twitter.com/1.1/media/upload.json',

--- a/lib/twitter/streaming/event.rb
+++ b/lib/twitter/streaming/event.rb
@@ -1,14 +1,14 @@
 module Twitter
   module Streaming
     class Event
-      LIST_EVENTS = [
-        :list_created, :list_destroyed, :list_updated, :list_member_added,
-        :list_member_added, :list_member_removed, :list_user_subscribed,
-        :list_user_subscribed, :list_user_unsubscribed, :list_user_unsubscribed
+      LIST_EVENTS = %i[
+        list_created list_destroyed list_updated list_member_added
+        list_member_added list_member_removed list_user_subscribed
+        list_user_subscribed list_user_unsubscribed list_user_unsubscribed
       ].freeze
 
-      TWEET_EVENTS = [
-        :favorite, :unfavorite, :quoted_tweet
+      TWEET_EVENTS = %i[
+        favorite unfavorite quoted_tweet
       ].freeze
 
       attr_reader :name, :source, :target, :target_object

--- a/spec/twitter/direct_message_spec.rb
+++ b/spec/twitter/direct_message_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::DirectMessage do

--- a/spec/twitter/entity/uri_spec.rb
+++ b/spec/twitter/entity/uri_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::Entity::URI do

--- a/spec/twitter/error_spec.rb
+++ b/spec/twitter/error_spec.rb
@@ -26,7 +26,7 @@ describe Twitter::Error do
     end
   end
 
-  %w(error errors).each do |key|
+  %w[error errors].each do |key|
     context "when JSON body contains #{key}" do
       before do
         body = "{\"#{key}\":\"Internal Server Error\"}"

--- a/spec/twitter/rest/favorites_spec.rb
+++ b/spec/twitter/rest/favorites_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::REST::Favorites do

--- a/spec/twitter/rest/tweets_spec.rb
+++ b/spec/twitter/rest/tweets_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::REST::Tweets do

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::Tweet do

--- a/spec/twitter/user_spec.rb
+++ b/spec/twitter/user_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::User do

--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -16,12 +16,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ['Erik Michaels-Ober', 'John Nunemaker', 'Wynn Netherland', 'Steve Richert', 'Steve Agalloco']
   spec.description = 'A Ruby interface to the Twitter API.'
-  spec.email = %w(sferik@gmail.com)
-  spec.files = %w(.yardopts CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md twitter.gemspec) + Dir['lib/**/*.rb']
+  spec.email = %w[sferik@gmail.com]
+  spec.files = %w[.yardopts CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md twitter.gemspec] + Dir['lib/**/*.rb']
   spec.homepage = 'http://sferik.github.com/twitter/'
-  spec.licenses = %w(MIT)
+  spec.licenses = %w[MIT]
   spec.name = 'twitter'
-  spec.require_paths = %w(lib)
+  spec.require_paths = %w[lib]
   spec.required_ruby_version = '>= 1.9.3'
   spec.summary = spec.description
   spec.version = Twitter::Version


### PR DESCRIPTION
Great gem! Thanks for your work

Just cloned to run the tests and check out the code and the latest version of rubocop flagged some new issues. Also added `vendor/` to `.gitignore`

Tests are green on every MRI back to 2.0.0