### PR TITLE
Support tweet_mode=extended

### DIFF
--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -7,7 +7,7 @@ module Twitter
     include Twitter::Creatable
     include Twitter::Entities
     # @return [String]
-    attr_reader :filter_level, :in_reply_to_screen_name, :lang, :source, :text
+    attr_reader :filter_level, :in_reply_to_screen_name, :lang, :source
     # @return [Integer]
     attr_reader :favorite_count, :in_reply_to_status_id, :in_reply_to_user_id,
                 :retweet_count
@@ -28,6 +28,10 @@ module Twitter
     object_attr_reader :User, :user, :status
     predicate_attr_reader :favorited, :possibly_sensitive, :retweeted,
                           :truncated
+
+    def text
+      attrs[:full_text] || attrs[:text]
+    end
 
     # @note May be > 140 characters.
     # @return [String]


### PR DESCRIPTION
I noticed that a bunch of my tweets were coming back truncated. I've tweaked the `Tweet` class slightly so that I can use `tweet_mode=extended` when requesting a timeline etc to return the full Tweets.

More information here: https://dev.twitter.com/overview/api/upcoming-changes-to-tweets