### PR TITLE
Add TCP keepalive in Twitter::Streaming::Connection

### DIFF
--- a/lib/twitter/streaming/connection.rb
+++ b/lib/twitter/streaming/connection.rb
@@ -5,7 +5,7 @@ require 'resolv'
 module Twitter
   module Streaming
     class Connection
-      attr_reader :tcp_socket_class, :ssl_socket_class
+      attr_reader :tcp_socket_class, :ssl_socket_class, :keepalive
 
       DEFAULT_KEEPALIVE_SETTINGS = {
         enabled: true,

--- a/spec/twitter/streaming/connection_spec.rb
+++ b/spec/twitter/streaming/connection_spec.rb
@@ -9,6 +9,10 @@ describe Twitter::Streaming::Connection do
         expect(connection.tcp_socket_class).to eq TCPSocket
         expect(connection.ssl_socket_class).to eq OpenSSL::SSL::SSLSocket
       end
+
+      it 'sets keepalive as disabled' do
+        expect(connection.keepalive).to include(enabled: false)
+      end
     end
 
     context 'custom socket classes provided in opts' do
@@ -22,6 +26,23 @@ describe Twitter::Streaming::Connection do
       it 'sets the default socket classes' do
         expect(connection.tcp_socket_class).to eq DummyTCPSocket
         expect(connection.ssl_socket_class).to eq DummySSLSocket
+      end
+    end
+
+    context 'custom keepalive settings' do
+      let(:keepalive_settings) do
+        {
+          enabled: true,
+          idle_timeout: 30,
+          interval: 15,
+          count: 10
+        }
+      end
+
+      subject(:connection) { Twitter::Streaming::Connection.new(keepalive: keepalive_settings) }
+
+      it "uses the custom keepalive settings" do
+        expect(connection.keepalive).to eq keepalive_settings
       end
     end
   end
@@ -45,7 +66,7 @@ describe Twitter::Streaming::Connection do
 
     let(:request) { HTTP::Request.new(verb: method, uri: uri) }
 
-    it 'requests via the proxy' do
+    it 'requests directly' do
       expect(connection.ssl_socket_class).to receive(:new).and_return(ssl_socket)
       allow(ssl_socket).to receive(:connect)
 
@@ -73,6 +94,55 @@ describe Twitter::Streaming::Connection do
 
           expect(connection).to receive(:new_tcp_socket).with('127.0.0.1', 3328)
           connection.connect(request)
+        end
+      end
+    end
+
+    context 'with keepalive settings' do
+      subject(:connection) { Twitter::Streaming::Connection.new(keepalive: keepalive_settings, ssl_socket_class: DummySSLSocket) }
+
+      let(:keepalive_settings) do
+        {
+          enabled: true,
+          idle_timeout: 30,
+          interval: 15,
+          count: 10,
+        }
+      end
+
+      let(:socket) { instance_double(TCPSocket) }
+
+      before do
+        allow(Resolv).to receive(:getaddress).and_return('104.244.42.1')
+        allow(TCPSocket).to receive(:new).and_return(socket)
+        allow(socket).to receive(:setsockopt)
+        allow(DummySSLSocket).to receive(:new).and_return(ssl_socket)
+        allow(ssl_socket).to receive(:connect)
+      end
+
+      it 'sets the keepalive settings if able' do
+        stub_const('Socket::SO_KEEPALIVE', :SO_KEEPALIVE)
+        stub_const('Socket::TCP_KEEPIDLE', :TCP_KEEPIDLE)
+        stub_const('Socket::TCP_KEEPINTVL', :TCP_KEEPINTVL)
+        stub_const('Socket::TCP_KEEPCNT', :TCP_KEEPCNT)
+        stub_const('Socket::SOL_SOCKET', :SOL_SOCKET)
+        stub_const('Socket::IPPROTO_TCP', :IPPROTO_TCP)
+
+        connection.connect(request)
+
+        expect(socket).to have_received(:setsockopt).with(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
+        expect(socket).to have_received(:setsockopt).with(Socket::IPPROTO_TCP, Socket::TCP_KEEPIDLE, 30)
+        expect(socket).to have_received(:setsockopt).with(Socket::IPPROTO_TCP, Socket::TCP_KEEPINTVL, 15)
+        expect(socket).to have_received(:setsockopt).with(Socket::IPPROTO_TCP, Socket::TCP_KEEPCNT, 10)
+      end
+
+      context 'with keepalive disabled' do
+        let(:keepalive_settings) { {enabled: false} }
+
+        it 'does not attempt to set keepalive settings' do
+          connection.connect(request)
+
+          expect(socket).not_to have_received(:setsockopt)
         end
       end
     end


### PR DESCRIPTION
Without correct TCP keepalive setup, the Twitter streaming client is prone to hang on long-lived connections. This is due to the nature of the protocol: a single request is made, then the client simply waits for data to read on a socket. Without keepalive, it may be indistinguishable to the client whether the connection has failed or there is simply no data to read.

These changes add the ability to set TCP keepalive providing the OS supports it. They also provide a set of sensible defaults to the keepalive for this implementation, while disabled by default.