### PR TITLE
Relax faraday constraint from 0.11.0 to 0.11

### DIFF
--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'buftok', '~> 0.2.0'
   spec.add_dependency 'equalizer', '0.0.11'
-  spec.add_dependency 'faraday', '~> 0.11.0'
+  spec.add_dependency 'faraday', '~> 0.11'
   spec.add_dependency 'http', '~> 2.1'
   spec.add_dependency 'http_parser.rb', '~> 0.6.0'
   spec.add_dependency 'memoizable', '~> 0.4.2'


### PR DESCRIPTION
This way, a bundle can upgrade to faraday 0.12 without getting constraint violations.