### PR TITLE
[6 stable] Fix rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,12 @@
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -24,9 +33,6 @@ Metrics/ParameterLists:
   Max: 4
   CountKeywordArgs: true
 
-Style/AccessModifierIndentation:
-  EnforcedStyle: outdent
-
 Style/CollectionMethods:
   PreferredMethods:
     map:      'collect'
@@ -36,9 +42,6 @@ Style/CollectionMethods:
 
 Style/Documentation:
   Enabled: false
-
-Style/DotPosition:
-  EnforcedStyle: trailing
 
 Style/DoubleNegation:
   Enabled: false
@@ -55,9 +58,6 @@ Style/PercentLiteralDelimiters:
 
 Style/RaiseArgs:
   EnforcedStyle: compact
-
-Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
 
 Style/SymbolArray:
   EnforcedStyle: brackets

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ Metrics/AbcSize:
   Enabled: false
 
 Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
   Max: 36
 
 Metrics/BlockNesting:
@@ -47,11 +49,18 @@ Style/Encoding:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%w': ()
+
 Style/RaiseArgs:
   EnforcedStyle: compact
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
 
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'

--- a/lib/twitter/profile.rb
+++ b/lib/twitter/profile.rb
@@ -88,7 +88,7 @@ module Twitter
     end
 
     def profile_image_suffix(size)
-      :original == size.to_sym ? '\\1' : "_#{size}\\1"
+      size.to_sym == :original ? '\\1' : "_#{size}\\1"
     end
   end
 end

--- a/spec/twitter/direct_message_spec.rb
+++ b/spec/twitter/direct_message_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::DirectMessage do

--- a/spec/twitter/entity/uri_spec.rb
+++ b/spec/twitter/entity/uri_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::Entity::URI do

--- a/spec/twitter/media/photo_spec.rb
+++ b/spec/twitter/media/photo_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::Media::Photo do

--- a/spec/twitter/rest/favorites_spec.rb
+++ b/spec/twitter/rest/favorites_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::REST::Favorites do

--- a/spec/twitter/rest/tweets_spec.rb
+++ b/spec/twitter/rest/tweets_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::REST::Tweets do

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::Tweet do

--- a/spec/twitter/user_spec.rb
+++ b/spec/twitter/user_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 require 'helper'
 
 describe Twitter::User do


### PR DESCRIPTION
Update RuboCop configuration for RuboCop 0.49.1 and fix some offenses.

This should help make builds pass for new PRs.