### PR TITLE
Update the error message for Twitter::Error::AlreadyRetweeted

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -77,6 +77,7 @@ module Twitter
     FORBIDDEN_MESSAGES = {
       'Status is a duplicate.' => Twitter::Error::DuplicateStatus,
       'You have already favorited this status.' => Twitter::Error::AlreadyFavorited,
+      'You have already retweeted this tweet.' => Twitter::Error::AlreadyRetweeted,
       'sharing is not permissible for this status (Share validations failed)' => Twitter::Error::AlreadyRetweeted,
     }.freeze
 

--- a/spec/fixtures/already_retweeted.json
+++ b/spec/fixtures/already_retweeted.json
@@ -1,1 +1,1 @@
-{"errors":"sharing is not permissible for this status (Share validations failed)"}
+{"errors":"You have already retweeted this tweet."}


### PR DESCRIPTION
The old message is kept just in case it still occurs.

Here's my local workaround:
```ruby
Twitter::Error::FORBIDDEN_MESSAGES = Twitter::Error.send(:remove_const, :FORBIDDEN_MESSAGES).merge(
  'You have already retweeted this tweet.' => Twitter::Error::AlreadyRetweeted
).freeze
```
