### PR TITLE
Support closing stream

### DIFF
--- a/lib/twitter/streaming/client.rb
+++ b/lib/twitter/streaming/client.rb
@@ -105,6 +105,10 @@ module Twitter
         end
       end
 
+      def close
+        @connection.close
+      end
+
     private
 
       def request(method, uri, params)

--- a/lib/twitter/streaming/connection.rb
+++ b/lib/twitter/streaming/connection.rb
@@ -11,14 +11,23 @@ module Twitter
         @tcp_socket_class = options.fetch(:tcp_socket_class) { TCPSocket }
         @ssl_socket_class = options.fetch(:ssl_socket_class) { OpenSSL::SSL::SSLSocket }
         @using_ssl        = options.fetch(:using_ssl)        { false }
+        @write_pipe = nil
       end
 
       def stream(request, response)
         client = connect(request)
         request.stream(client)
-        while body = client.readpartial(1024) # rubocop:disable AssignmentInCondition
-          response << body
+        read_pipe, @write_pipe = IO.pipe
+        loop do
+          read_ios, _write_ios, _exception_ios = IO.select([read_pipe, client])
+          case read_ios.first
+          when client
+            response << client.readpartial(1024)
+          when read_pipe
+            break
+          end
         end
+        client.close
       end
 
       def connect(request)
@@ -28,6 +37,10 @@ module Twitter
         client_context = OpenSSL::SSL::SSLContext.new
         ssl_client     = @ssl_socket_class.new(client, client_context)
         ssl_client.connect
+      end
+
+      def close
+        @write_pipe.write('q') if @write_pipe
       end
 
     private

--- a/lib/twitter/streaming/connection.rb
+++ b/lib/twitter/streaming/connection.rb
@@ -14,7 +14,7 @@ module Twitter
         @write_pipe = nil
       end
 
-      def stream(request, response)
+      def stream(request, response) # rubocop:disable MethodLength
         client = connect(request)
         request.stream(client)
         read_pipe, @write_pipe = IO.pipe

--- a/spec/twitter/streaming/connection_spec.rb
+++ b/spec/twitter/streaming/connection_spec.rb
@@ -108,6 +108,7 @@ describe Twitter::Streaming::Connection do
         stream_closed = true
       end
       expect(stream_closed).to be false
+      sleep 1
       connection.close
       t.join
       expect(stream_closed).to be true

--- a/spec/twitter/streaming/connection_spec.rb
+++ b/spec/twitter/streaming/connection_spec.rb
@@ -85,13 +85,13 @@ describe Twitter::Streaming::Connection do
 
     let(:method) { :get }
     let(:uri)    { 'https://stream.twitter.com:443/1.1/statuses/sample.json' }
-    let(:client) {  TCPSocket.new('127.0.0.1', 11443) }
+    let(:client) {  TCPSocket.new('127.0.0.1', 8443) }
 
     let(:request) { HTTP::Request.new(verb: method, uri: uri) }
     let(:response) { DummyResponse.new {} }
 
     before do
-      @server = TCPServer.new('127.0.0.1', 11443)
+      @server = TCPServer.new('127.0.0.1', 8443)
     end
 
     after do

--- a/spec/twitter/streaming/connection_spec.rb
+++ b/spec/twitter/streaming/connection_spec.rb
@@ -77,4 +77,40 @@ describe Twitter::Streaming::Connection do
       end
     end
   end
+
+  describe 'stream' do
+    subject(:connection) do
+      Twitter::Streaming::Connection.new(tcp_socket_class: DummyTCPSocket, ssl_socket_class: DummySSLSocket)
+    end
+
+    let(:method) { :get }
+    let(:uri)    { 'https://stream.twitter.com:443/1.1/statuses/sample.json' }
+    let(:client) {  TCPSocket.new('127.0.0.1', 11443) }
+
+    let(:request) { HTTP::Request.new(verb: method, uri: uri) }
+    let(:response) { DummyResponse.new {} }
+
+    before do
+      @server = TCPServer.new('127.0.0.1', 11443)
+    end
+
+    after do
+      @server.close
+    end
+
+    it 'close stream' do
+      expect(connection).to receive(:connect).with(request).and_return(client)
+      expect(request).to receive(:stream).with(client)
+
+      stream_closed = false
+      t = Thread.start do
+        connection.stream(request, response)
+        stream_closed = true
+      end
+      expect(stream_closed).to be false
+      connection.close
+      t.join
+      expect(stream_closed).to be true
+    end
+  end
 end


### PR DESCRIPTION
In this version, we can close stream as following:

```ruby
client = Twitter::Streaming::Client.new do |config|
  # Set up configuration
end

t = Thread.new do
  client.filter(track: keyword) do |object|
    # process object
  end
end

Signal.trap(:TERM) do
  # terminate process silently
  client.close
  exit true
end
```