### PR TITLE
Big gifs chunk upload

### DIFF
--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -327,32 +327,38 @@ module Twitter
       # The only supported video format is mp4.
       #
       # @see https://dev.twitter.com/rest/public/uploading-media
-      def upload(media) # rubocop:disable MethodLength, AbcSize
-        if File.basename(media) !~ /\.mp4$/
-          Twitter::REST::Request.new(self, :multipart_post, 'https://upload.twitter.com/1.1/media/upload.json', key: :media, file: media).perform
-        else
-          init = Twitter::REST::Request.new(self, :post, 'https://upload.twitter.com/1.1/media/upload.json',
-                                            command: 'INIT',
-                                            media_type: 'video/mp4',
-                                            total_bytes: media.size).perform
+      def upload(media)
+        return chunk_upload(media, 'video/mp4', 'tweet_video') if File.extname(media) == '.mp4'
+        return chunk_upload(media, 'image/gif', 'tweet_gif') if File.extname(media) == '.gif' && File.size(media) > 5_000_000
 
-          until media.eof?
-            chunk = media.read(5_000_000)
-            seg ||= -1
-            Twitter::REST::Request.new(self, :multipart_post, 'https://upload.twitter.com/1.1/media/upload.json',
-                                       command: 'APPEND',
-                                       media_id: init[:media_id],
-                                       segment_index: seg += 1,
-                                       key: :media,
-                                       file: StringIO.new(chunk)).perform
-          end
-
-          media.close
-
-          Twitter::REST::Request.new(self, :post, 'https://upload.twitter.com/1.1/media/upload.json',
-                                     command: 'FINALIZE', media_id: init[:media_id]).perform
-        end
+        Twitter::REST::Request.new(self, :multipart_post, 'https://upload.twitter.com/1.1/media/upload.json', key: :media, file: media).perform
       end
+
+      # rubocop:disable MethodLength
+      def chunk_upload(media, media_type, media_category)
+        init = Twitter::REST::Request.new(self, :post, 'https://upload.twitter.com/1.1/media/upload.json',
+                                          command: 'INIT',
+                                          media_type: media_type,
+                                          media_category: media_category,
+                                          total_bytes: media.size).perform
+
+        until media.eof?
+          chunk = media.read(5_000_000)
+          seg ||= -1
+          Twitter::REST::Request.new(self, :multipart_post, 'https://upload.twitter.com/1.1/media/upload.json',
+                                     command: 'APPEND',
+                                     media_id: init[:media_id],
+                                     segment_index: seg += 1,
+                                     key: :media,
+                                     file: StringIO.new(chunk)).perform
+        end
+
+        media.close
+
+        Twitter::REST::Request.new(self, :post, 'https://upload.twitter.com/1.1/media/upload.json',
+                                   command: 'FINALIZE', media_id: init[:media_id]).perform
+      end
+      # rubocop:enable MethodLength
 
       def array_wrap(object)
         if object.respond_to?(:to_ary)

--- a/spec/twitter/rest/request_spec.rb
+++ b/spec/twitter/rest/request_spec.rb
@@ -31,7 +31,7 @@ describe Twitter::REST::Request do
       it 'requests via the proxy when uploaded media is present' do
         stub_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').to_return(body: fixture('upload.json'), headers: {content_type: 'application/json; charset=utf-8'})
         stub_post('/1.1/statuses/update.json').with(body: {status: 'Update', media_ids: '470030289822314497'}).to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
-        expect(HTTP).to receive(:via).with('127.0.0.1', 3328).twice.times.and_call_original
+        expect(HTTP).to receive(:via).with('127.0.0.1', 3328).twice.and_call_original
         @client.update_with_media('Update', fixture('pbjt.gif'))
       end
 

--- a/spec/twitter/rest/request_spec.rb
+++ b/spec/twitter/rest/request_spec.rb
@@ -31,7 +31,7 @@ describe Twitter::REST::Request do
       it 'requests via the proxy when uploaded media is present' do
         stub_request(:post, 'https://upload.twitter.com/1.1/media/upload.json').to_return(body: fixture('upload.json'), headers: {content_type: 'application/json; charset=utf-8'})
         stub_post('/1.1/statuses/update.json').with(body: {status: 'Update', media_ids: '470030289822314497'}).to_return(body: fixture('status.json'), headers: {content_type: 'application/json; charset=utf-8'})
-        expect(HTTP).to receive(:via).with('127.0.0.1', 3328).twice.and_call_original
+        expect(HTTP).to receive(:via).with('127.0.0.1', 3328).twice.times.and_call_original
         @client.update_with_media('Update', fixture('pbjt.gif'))
       end
 

--- a/spec/twitter/rest/tweets_spec.rb
+++ b/spec/twitter/rest/tweets_spec.rb
@@ -422,6 +422,22 @@ describe Twitter::REST::Tweets do
         expect(tweet).to be_a Twitter::Tweet
         expect(tweet.text).to eq('Powerful cartoon by @BillBramhall: http://t.co/IOEbc5QoES')
       end
+      context 'which size is bigger than 5 megabytes' do
+        let(:big_gif) { fixture('pbjt.gif') }
+        before do
+          expect(File).to receive(:size).with(big_gif).and_return(7_000_000)
+        end
+        it 'requests the correct resource' do
+          @client.update_with_media('Powerful cartoon by @BillBramhall: http://t.co/IOEbc5QoES', big_gif)
+          expect(a_request(:post, 'https://upload.twitter.com/1.1/media/upload.json')).to have_been_made.times(3)
+          expect(a_post('/1.1/statuses/update.json')).to have_been_made
+        end
+        it 'returns a Tweet' do
+          tweet = @client.update_with_media('Powerful cartoon by @BillBramhall: http://t.co/IOEbc5QoES', big_gif)
+          expect(tweet).to be_a Twitter::Tweet
+          expect(tweet.text).to eq('Powerful cartoon by @BillBramhall: http://t.co/IOEbc5QoES')
+        end
+      end
     end
     context 'with a jpe image' do
       it 'requests the correct resource' do


### PR DESCRIPTION
Hello!

Awesome gem, thank you very much for your work! 
By method update_with_media can be uploaded only GIFs with size less than 5 megabytes, but Twitter allows to upload GIFs up to 15 megabytes by chunks. I've added support for this functionality and covered it with specs.