### PR TITLE
Follow Twitter API which again changed the message for already retweeted error

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -74,12 +74,21 @@ module Twitter
       504 => Twitter::Error::GatewayTimeout,
     }.freeze
 
-    FORBIDDEN_MESSAGES = {
-      'Status is a duplicate.' => Twitter::Error::DuplicateStatus,
-      'You have already favorited this status.' => Twitter::Error::AlreadyFavorited,
-      'You have already retweeted this tweet.' => Twitter::Error::AlreadyRetweeted,
-      'sharing is not permissible for this status (Share validations failed)' => Twitter::Error::AlreadyRetweeted,
-    }.freeze
+    FORBIDDEN_MESSAGES = proc do |message|
+      case message
+      when /(?=.*status).*duplicate/i
+        # - "Status is a duplicate."
+        Twitter::Error::DuplicateStatus
+      when /already favorited/i
+        # - "You have already favorited this status."
+        Twitter::Error::AlreadyFavorited
+      when /already retweeted|Share validations failed/i
+        # - "You have already retweeted this Tweet." (Nov 2017-)
+        # - "You have already retweeted this tweet." (?-Nov 2017)
+        # - "sharing is not permissible for this status (Share validations failed)" (-? 2017)
+        Twitter::Error::AlreadyRetweeted
+      end
+    end
 
     # If error code is missing see https://dev.twitter.com/overview/api/response-codes
     module Code

--- a/spec/fixtures/already_retweeted.json
+++ b/spec/fixtures/already_retweeted.json
@@ -1,1 +1,1 @@
-{"errors":"You have already retweeted this tweet."}
+{"errors":"You have already retweeted this Tweet."}


### PR DESCRIPTION
They changed the message again after #875, and the latest message I can observe in my Twitter API failure log is "You have already retweeted this Tweet."  The only difference is the last word which got capitalized. (sigh...)

So, I think it's time to drop the message-to-error table based on exact string match.