### PR TITLE
handle json post requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ doc/*
 log/*
 measurement/*
 pkg/*
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'jruby-openssl', platforms: :jruby
 gem 'rake'
 gem 'yard'
 
-group :development do
+group :development, :test do
   gem 'pry'
 end
 

--- a/lib/twitter/rest/request_options.rb
+++ b/lib/twitter/rest/request_options.rb
@@ -1,0 +1,62 @@
+require 'twitter/headers'
+
+module Twitter
+  module REST
+    module RequestOptions
+      def create_request_options!(request_method, options)
+        if request_method == :multipart_post
+          create_multipart_options!(options)
+        elsif request_method == :json_post
+          create_json_options!
+        else
+          create_standard_options!(request_method, options)
+        end
+      end
+
+    private
+
+      def merge_multipart_file!(options)
+        key = options.delete(:key)
+        file = options.delete(:file)
+
+        options[key] = if file.is_a?(StringIO)
+                         HTTP::FormData::File.new(file, mime_type: 'video/mp4')
+                       else
+                         HTTP::FormData::File.new(file, filename: File.basename(file), mime_type: mime_type(File.basename(file)))
+                       end
+      end
+
+      def create_multipart_options!(options)
+        merge_multipart_file!(options)
+        @request_method = :post
+        @options_key = :form
+        @headers = Twitter::Headers.new(@client, @request_method, @uri).request_headers
+      end
+
+      def create_json_options!
+        @options_key = :json
+        @request_method = :post
+        @headers = Twitter::Headers.new(@client, @request_method, @uri).request_headers
+      end
+
+      def create_standard_options!(request_method, options)
+        @request_method = request_method
+        @options_key = @request_method == :get ? :params : :form
+        @headers = Twitter::Headers.new(@client, @request_method, @uri, options).request_headers
+      end
+
+      def mime_type(basename)
+        case basename
+        when /\.gif$/i
+          'image/gif'
+        when /\.jpe?g/i
+          'image/jpeg'
+        when /\.png$/i
+          'image/png'
+        else
+          'application/octet-stream'
+        end
+      end
+    end
+  end
+end

--- a/lib/twitter/rest/request_options.rb
+++ b/lib/twitter/rest/request_options.rb
@@ -3,6 +3,11 @@ require 'twitter/headers'
 module Twitter
   module REST
     module RequestOptions
+      # Set the request method, content type, and headers on the client
+      #
+      # @param request_method [Symbol] Desired request method
+      # @param options [Hash] the content body
+      # @return [void]
       def create_request_options!(request_method, options)
         if request_method == :multipart_post
           create_multipart_options!(options)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -15,6 +15,7 @@ require 'stringio'
 require 'tempfile'
 require 'timecop'
 require 'webmock/rspec'
+require 'pry'
 
 require_relative 'support/media_object_examples'
 

--- a/spec/twitter/rest/request_spec.rb
+++ b/spec/twitter/rest/request_spec.rb
@@ -22,14 +22,14 @@ describe Twitter::REST::Request do
     context 'when posting JSON' do
       it 'makes a proper json encoded request' do
         stub_post('/1.1/json-post-endpoint.json')
-          .with({
+          .with(
             body: {test_key: 'test value'},
             headers: {content_type: 'application/json; charset=UTF-8'}
-          })
-          .to_return({
+          )
+          .to_return(
             body: '{"success":true}',
             headers: {content_type: 'application/json; charset=utf-8'}
-          })
+          )
         Twitter::REST::Request.new(@client, :json_post, '/1.1/json-post-endpoint.json', test_key: 'test value').perform
         expect(a_post('/1.1/json-post-endpoint.json').with(body: {test_key: 'test value'})).to have_been_made
       end

--- a/spec/twitter/rest/request_spec.rb
+++ b/spec/twitter/rest/request_spec.rb
@@ -19,6 +19,22 @@ describe Twitter::REST::Request do
       expect(a_post('/1.1/statuses/update.json').with(body: {status: 'Update', media_ids: '470030289822314497'})).to have_been_made
     end
 
+    context 'when posting JSON' do
+      it 'makes a proper json encoded request' do
+        stub_post('/1.1/json-post-endpoint.json')
+          .with({
+            body: {test_key: 'test value'},
+            headers: {content_type: 'application/json; charset=UTF-8'}
+          })
+          .to_return({
+            body: '{"success":true}',
+            headers: {content_type: 'application/json; charset=utf-8'}
+          })
+        Twitter::REST::Request.new(@client, :json_post, '/1.1/json-post-endpoint.json', test_key: 'test value').perform
+        expect(a_post('/1.1/json-post-endpoint.json').with(body: {test_key: 'test value'})).to have_been_made
+      end
+    end
+
     context 'when using a proxy' do
       before do
         @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS', proxy: {host: '127.0.0.1', port: 3328})

--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.licenses = %w[MIT]
   spec.name = 'twitter'
   spec.require_paths = %w[lib]
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.1.0'
   spec.summary = spec.description
   spec.version = Twitter::Version
 end


### PR DESCRIPTION
This adds basic support for sending authenticated JSON post requests.
Resolves #862
Also resolves #869 

Example usage:

```ruby
    Twitter::REST::Request.new(
      client, # Twitter::REST::Client instance
      :json_post, # <-- this is important
      '/1.1/the-endpoint.json',
      {
        some_key: "some value",
      }
    ).perform
```