### PR TITLE
docs: Fix proxy setting sample code

### DIFF
--- a/examples/Configuration.md
+++ b/examples/Configuration.md
@@ -131,11 +131,12 @@ If you'd like to connect via a proxy, a proxy can be configured by passing a
 `Hash` to your configuration:
 
 ```ruby
-  proxy: {
-    uri: Addressable::URI.parse("http://proxy_host:proxy_port"),
-    username: "proxy_username",
-    password: "proxy_password"
-  }
+proxy = {
+  host: "proxy.example.com",
+  port: 8080,
+  username: "proxy_username",
+  password: "proxy_password"
+}
 
 client = Twitter::REST::Client.new do |config|
   config.consumer_key        = "YOUR_CONSUMER_KEY"


### PR DESCRIPTION
Current code doesn't work. I got following error:

```
/usr/src/app/vendor/bundle/ruby/2.2.0/gems/http-3.0.0/lib/http/chainable.rb:164:in `via': invalid HTTP proxy: {} (HTTP::RequestError)
 from /usr/src/app/vendor/bundle/ruby/2.2.0/gems/twitter-6.2.0/lib/twitter/rest/request.rb:120:in `http_client'
 from /usr/src/app/vendor/bundle/ruby/2.2.0/gems/twitter-6.2.0/lib/twitter/rest/request.rb:36:in `perform'
 from /usr/src/app/vendor/bundle/ruby/2.2.0/gems/twitter-6.2.0/lib/twitter/search_results.rb:26:in `initialize'
 from /usr/src/app/vendor/bundle/ruby/2.2.0/gems/twitter-6.2.0/lib/twitter/rest/search.rb:33:in `new'
 from /usr/src/app/vendor/bundle/ruby/2.2.0/gems/twitter-6.2.0/lib/twitter/rest/search.rb:33:in `search'
 from test.rb:10:in `<main>'
```

See:
- https://github.com/sferik/twitter/blob/master/lib/twitter/rest/request.rb#L129
- https://github.com/httprb/http/blob/v3.0.0/lib/http/chainable.rb#L164
