### PR TITLE
Pass rubocop and codeclimat

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,3 @@
-AllCops:
-  TargetRubyVersion: 2.1
-
 Gemspec/RequiredRubyVersion:
   Enabled: false
 
@@ -56,9 +53,3 @@ Style/FrozenStringLiteralComment:
 
 Style/NumericPredicate:
   Enabled: false
-
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: 'comma'
-
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: 'comma'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,9 @@
+AllCops:
+  TargetRubyVersion: 2.1
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
@@ -51,5 +57,8 @@ Style/FrozenStringLiteralComment:
 Style/NumericPredicate:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: 'comma'

--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -35,7 +35,7 @@ module Twitter
         consumer_key: consumer_key,
         consumer_secret: consumer_secret,
         token: access_token,
-        token_secret: access_token_secret,
+        token_secret: access_token_secret
       }
     end
 

--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -46,8 +46,8 @@ module Twitter
 
   private
 
-    def blank?(s)
-      s.respond_to?(:empty?) ? s.empty? : !s
+    def blank?(str)
+      str.respond_to?(:empty?) ? str.empty? : !str
     end
   end
 end

--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -71,14 +71,14 @@ module Twitter
       500 => Twitter::Error::InternalServerError,
       502 => Twitter::Error::BadGateway,
       503 => Twitter::Error::ServiceUnavailable,
-      504 => Twitter::Error::GatewayTimeout,
+      504 => Twitter::Error::GatewayTimeout
     }.freeze
 
     FORBIDDEN_MESSAGES = {
       'Status is a duplicate.' => Twitter::Error::DuplicateStatus,
       'You have already favorited this status.' => Twitter::Error::AlreadyFavorited,
       'You have already retweeted this tweet.' => Twitter::Error::AlreadyRetweeted,
-      'sharing is not permissible for this status (Share validations failed)' => Twitter::Error::AlreadyRetweeted,
+      'sharing is not permissible for this status (Share validations failed)' => Twitter::Error::AlreadyRetweeted
     }.freeze
 
     # If error code is missing see https://dev.twitter.com/overview/api/response-codes

--- a/lib/twitter/rest/search.rb
+++ b/lib/twitter/rest/search.rb
@@ -26,10 +26,10 @@ module Twitter
       # @option options [Integer] :max_id Returns results with an ID less than (that is, older than) or equal to the specified ID.
       # @option options [Boolean] :include_entities The entities node will be disincluded when set to false.
       # @return [Twitter::SearchResults] Return tweets that match a specified query with search metadata
-      def search(q, options = {})
+      def search(query, options = {})
         options = options.dup
         options[:count] ||= MAX_TWEETS_PER_REQUEST
-        request = Twitter::REST::Request.new(self, :get, '/1.1/search/tweets.json', options.merge(q: q))
+        request = Twitter::REST::Request.new(self, :get, '/1.1/search/tweets.json', options.merge(q: query))
         Twitter::SearchResults.new(request)
       end
     end

--- a/lib/twitter/version.rb
+++ b/lib/twitter/version.rb
@@ -28,7 +28,7 @@ module Twitter
         major: major,
         minor: minor,
         patch: patch,
-        pre: pre,
+        pre: pre
       }
     end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -59,7 +59,7 @@ def stub_put(path)
 end
 
 def fixture_path
-  File.expand_path('../fixtures', __FILE__)
+  File.expand_path('fixtures', __dir__)
 end
 
 def fixture(file)

--- a/spec/twitter/direct_message_spec.rb
+++ b/spec/twitter/direct_message_spec.rb
@@ -58,8 +58,8 @@ describe Twitter::DirectMessage do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       tweet = Twitter::DirectMessage.new(id: 1_825_786_345, entities: {urls: urls_array})
       expect(tweet.entities?).to be true
@@ -123,8 +123,8 @@ describe Twitter::DirectMessage do
       hashtags_array = [
         {
           text: 'twitter',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       hashtags = Twitter::DirectMessage.new(id: 1_825_786_345, entities: {hashtags: hashtags_array}).hashtags
       expect(hashtags).to be_an Array
@@ -154,7 +154,7 @@ describe Twitter::DirectMessage do
     it 'returns an array of Entity::Symbol when symbols are set' do
       symbols_array = [
         {text: 'PEP', indices: [114, 118]},
-        {text: 'COKE', indices: [128, 133]},
+        {text: 'COKE', indices: [128, 133]}
       ]
       symbols = Twitter::DirectMessage.new(id: 1_825_786_345, entities: {symbols: symbols_array}).symbols
       expect(symbols).to be_an Array
@@ -176,8 +176,8 @@ describe Twitter::DirectMessage do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       direct_message = Twitter::DirectMessage.new(id: 1_825_786_345, entities: {urls: urls_array})
       expect(direct_message.uris).to be_an Array
@@ -196,8 +196,8 @@ describe Twitter::DirectMessage do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://with_underscore.example.com/expanded',
           display_url: 'with_underscore.example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       direct_message = Twitter::DirectMessage.new(id: 1_825_786_345, entities: {urls: urls_array})
       uri = direct_message.uris.first
@@ -215,8 +215,8 @@ describe Twitter::DirectMessage do
           name: 'Erik Michaels-Ober',
           id_str: '7_505_382',
           indices: [0, 6],
-          id: 7_505_382,
-        },
+          id: 7_505_382
+        }
       ]
       user_mentions = Twitter::DirectMessage.new(id: 1_825_786_345, entities: {user_mentions: user_mentions_array}).user_mentions
       expect(user_mentions).to be_an Array

--- a/spec/twitter/streaming/client_spec.rb
+++ b/spec/twitter/streaming/client_spec.rb
@@ -5,7 +5,7 @@ class FakeConnection
     @body = body
   end
 
-  def stream(_, response)
+  def stream(_request, response)
     @body.each_line do |line|
       response.on_body(line)
     end

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -58,8 +58,8 @@ describe Twitter::Tweet do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       tweet = Twitter::Tweet.new(id: 28_669_546_014, entities: {urls: urls_array})
       expect(tweet.entities?).to be true
@@ -135,7 +135,7 @@ describe Twitter::Tweet do
       let(:hashtags_array) do
         [{
           text: 'twitter',
-          indices: [10, 33],
+          indices: [10, 33]
         }]
       end
       let(:subject) do
@@ -330,7 +330,7 @@ describe Twitter::Tweet do
     it 'returns an array of Entity::Symbol when symbols are set' do
       symbols_array = [
         {text: 'PEP', indices: [114, 118]},
-        {text: 'COKE', indices: [128, 133]},
+        {text: 'COKE', indices: [128, 133]}
       ]
       symbols = Twitter::Tweet.new(id: 28_669_546_014, entities: {symbols: symbols_array}).symbols
       expect(symbols).to be_an Array
@@ -364,8 +364,8 @@ describe Twitter::Tweet do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       tweet = Twitter::Tweet.new(id: 28_669_546_014, entities: {urls: urls_array})
       expect(tweet.uris).to be_an Array
@@ -384,8 +384,8 @@ describe Twitter::Tweet do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://with_underscore.example.com/expanded',
           display_url: 'with_underscore.example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       tweet = Twitter::Tweet.new(id: 28_669_546_014, entities: {urls: urls_array})
       uri = tweet.uris.first
@@ -450,8 +450,8 @@ describe Twitter::Tweet do
           name: 'Erik Michaels-Ober',
           id_str: '7_505_382',
           indices: [0, 6],
-          id: 7_505_382,
-        },
+          id: 7_505_382
+        }
       ]
       user_mentions = Twitter::Tweet.new(id: 28_669_546_014, entities: {user_mentions: user_mentions_array}).user_mentions
       expect(user_mentions).to be_an Array

--- a/spec/twitter/user_spec.rb
+++ b/spec/twitter/user_spec.rb
@@ -49,8 +49,8 @@ describe Twitter::User do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       user = Twitter::User.new(id: 7_505_382, entities: {description: {urls: urls_array}})
       expect(user.description_uris).to be_an Array
@@ -71,8 +71,8 @@ describe Twitter::User do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       user = Twitter::User.new(id: 7_505_382, entities: {description: {urls: urls_array}})
       expect(user.description_uris?).to be true
@@ -90,8 +90,8 @@ describe Twitter::User do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [10, 33],
-        },
+          indices: [10, 33]
+        }
       ]
       user = Twitter::User.new(id: 7_505_382, entities: {description: {urls: urls_array}})
       expect(user.entities?).to be true
@@ -391,8 +391,8 @@ describe Twitter::User do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [0, 23],
-        },
+          indices: [0, 23]
+        }
       ]
       user = Twitter::User.new(id: 7_505_382, entities: {url: {urls: urls_array}})
       expect(user.website).to be_an Addressable::URI
@@ -415,8 +415,8 @@ describe Twitter::User do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [0, 23],
-        },
+          indices: [0, 23]
+        }
       ]
       user = Twitter::User.new(id: 7_505_382, entities: {url: {urls: urls_array}})
       expect(user.website?).to be true
@@ -434,8 +434,8 @@ describe Twitter::User do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [0, 23],
-        },
+          indices: [0, 23]
+        }
       ]
       user = Twitter::User.new(id: 7_505_382, entities: {url: {urls: urls_array}})
       expect(user.website_uris).to be_an Array
@@ -456,8 +456,8 @@ describe Twitter::User do
           url: 'https://t.co/L2xIBazMPf',
           expanded_url: 'http://example.com/expanded',
           display_url: 'example.com/expanded...',
-          indices: [0, 23],
-        },
+          indices: [0, 23]
+        }
       ]
       user = Twitter::User.new(id: 7_505_382, entities: {url: {urls: urls_array}})
       expect(user.website_uris?).to be true

--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'twitter/version'
 


### PR DESCRIPTION
- Removed `Style/TrailingCommaInLiteral` and changed to default (which code climat likes more)
- Disables `Gemspec/RequiredRubyVersion` to not offence unsupported by Rubocop 1.9.3
