### PR TITLE
Track rate limit when searching tweets

### DIFF
--- a/lib/twitter/search_results.rb
+++ b/lib/twitter/search_results.rb
@@ -9,7 +9,7 @@ module Twitter
     include Twitter::Enumerable
     include Twitter::Utils
     # @return [Hash]
-    attr_reader :attrs
+    attr_reader :attrs, :rate_limit
     alias to_h attrs
     alias to_hash to_h
 
@@ -48,8 +48,9 @@ module Twitter
 
     # @return [Hash]
     def fetch_next_page
-      response = Twitter::REST::Request.new(@client, @request_method, @path, @options.merge(next_page)).perform
-      self.attrs = response
+      response = Twitter::REST::Request.new(@client, @request_method, @path, @options.merge(next_page))
+      self.attrs = response.perform
+      @rate_limit = response.rate_limit
     end
 
     # @param attrs [Hash]

--- a/spec/twitter/search_results_spec.rb
+++ b/spec/twitter/search_results_spec.rb
@@ -14,8 +14,10 @@ describe Twitter::SearchResults do
     end
     it 'iterates' do
       count = 0
-      @client.search('#freebandnames').each { count += 1 }
+      search_results= @client.search('#freebandnames')
+      search_results.each { count += 1 }
       expect(count).to eq(6)
+      expect(search_results.rate_limit).to be_a(Twitter::RateLimit)
     end
     it 'passes through parameters to the next request' do
       stub_get('/1.1/search/tweets.json').with(query: {q: '#freebandnames', since_id: '414071360078878542', count: '100'}).to_return(body: fixture('search.json'), headers: {content_type: 'application/json; charset=utf-8'})


### PR DESCRIPTION
Hi!

Want to track limits while doing search requests to twitter API to looks like this:
```ruby
search = client.search('some query')
search.each do |tweet|
  # process tweets

  if search.rate_limit.remaining == 0
    # prevent continue to search and wait
  end
end
```