### PR TITLE
Replace text attribute with full_text if the extended Tweet has no text set

### DIFF
--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -29,6 +29,15 @@ module Twitter
     predicate_attr_reader :favorited, :possibly_sensitive, :retweeted,
                           :truncated
 
+    # Initializes a new object
+    #
+    # @param attrs [Hash]
+    # @return [Twitter::Tweet]
+    def initialize(attrs = {})
+      attrs[:text] = attrs[:full_text] if attrs[:text].nil? && !attrs[:full_text].nil?
+      super
+    end
+
     # @note May be > 280 characters.
     # @return [String]
     def full_text

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -92,6 +92,11 @@ describe Twitter::Tweet do
       expect(tweet.full_text).to be_a String
       expect(tweet.full_text).to eq('BOOSH')
     end
+    it 'returns the text of an extended Tweet' do
+      tweet = Twitter::Tweet.new(id: 28_669_546_014, text: nil, full_text: 'BOOSH')
+      expect(tweet.full_text).to be_a String
+      expect(tweet.full_text).to eq('BOOSH')
+    end
     it 'returns the text of a Tweet without a user' do
       tweet = Twitter::Tweet.new(id: 28_669_546_014, text: 'BOOSH', retweeted_status: {id: 28_561_922_517, text: 'BOOSH'})
       expect(tweet.full_text).to be_a String


### PR DESCRIPTION
Recently while attempting to use `Twitter::REST::Tweets#statuses` (gem version 6.2.0) I noticed that tweets had no text returned when the `tweet_mode: extended` option is set. 

To test this, I wrote a small script:
```
tweet_ids = ["922321981", "979854652618375168"]
client.statuses(tweet_ids).each_with_index do |tweet, i|
  puts "#{i+1}) Text: #{tweet.text}, Full Text: #{tweet.full_text}"
end
```
This will output the following (note that the second tweet is truncated):
```
1) Text: no, Full Text: no
2) Text: Guess what everyone? WE HIT 1000!! Thank you so much to all of my subscribers who helped us get here! Freya and I a… https://t.co/gL2HpqOgKt, Full Text: Guess what everyone? WE HIT 1000!! Thank you so much to all of my subscribers who helped us get here! Freya and I a… https://t.co/gL2HpqOgKt
```
If the script is changed so that `tweet_mode: extended` is set, the `#text` and `#full_text` values stop working:
```
tweet_ids = ["922321981", "979854652618375168"]
client.statuses(tweet_ids, tweet_mode: 'extended').each_with_index do |tweet, i|
  puts "#{i+1}) Text: #{tweet.text}, Full Text: #{tweet.full_text}"
end
```
```
1) Text: , Full Text:
2) Text: , Full Text:
```

I believe the problem is that when `tweet_mode: extended` is set, the call to GET statuses/lookup will return a `full_text` attribute instead of a `text` attribute. My fix checks for the presence of `full_text` instead of `text` on `Twitter::Tweet` creation, in order to avoid breaking the existing `#full_text` method.

If the patch is applied, the first, script above WITHOUT `tweet_mode` set returns the following truncated output, as before:
```
1) Text: no, Full Text: no
2) Text: Guess what everyone? WE HIT 1000!! Thank you so much to all of my subscribers who helped us get here! Freya and I a… https://t.co/gL2HpqOgKt, Full Text: Guess what everyone? WE HIT 1000!! Thank you so much to all of my subscribers who helped us get here! Freya and I a… https://t.co/gL2HpqOgKt
```

The second script, WITH `tweet_mode: extended` set, outputs the following:
```
1) Text: no, Full Text: no
2) Text: Guess what everyone? WE HIT 1000!! Thank you so much to all of my subscribers who helped us get here! Freya and I are so excited about what we have planned for the future and we are sure y'all are going to love it! Stay tuned this Tuesday for more info on the surprises! https://t.co/vwRhXyLSy6, Full Text: Guess what everyone? WE HIT 1000!! Thank you so much to all of my subscribers who helped us get here! Freya and I are so excited about what we have planned for the future and we are sure y'all are going to love it! Stay tuned this Tuesday for more info on the surprises! https://t.co/vwRhXyLSy6
```

This means that `Twitter::Tweet` will continue to work as before while also functioning properly for extended mode. I welcome any comments or feedback on the pull request!