### PR TITLE
Add require 'twitter' to readme configuration sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ error:
 You can pass configuration options as a block to `Twitter::REST::Client.new`.
 
 ```ruby
+require 'twitter'
+
 client = Twitter::REST::Client.new do |config|
   config.consumer_key        = "YOUR_CONSUMER_KEY"
   config.consumer_secret     = "YOUR_CONSUMER_SECRET"


### PR DESCRIPTION
I read README.md from the top, and executed configuration code at first.
I encountered `uninitialized constant Twitter` as below.

```
 irb
irb(main):001:0> client = Twitter::REST::Client.new do |config|
irb(main):002:1*   config.consumer_key        = "YOUR_CONSUMER_KEY"
irb(main):003:1>   config.consumer_secret     = "YOUR_CONSUMER_SECRET"
irb(main):004:1>   config.access_token        = "YOUR_ACCESS_TOKEN"
irb(main):005:1>   config.access_token_secret = "YOUR_ACCESS_SECRET"
irb(main):006:1> end
NameError: uninitialized constant Twitter
	from (irb):1
	from /Users/nao.kono/.rbenv/versions/2.3.5/bin/irb:11:in `<main>'
irb(main):007:0> 
```

To avoid this problem, I added `require 'twitter'` code.