### PR TITLE
Update http gem dependency to version 3.3

### DIFF
--- a/twitter.gemspec
+++ b/twitter.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_dependency 'buftok', '~> 0.2.0'
   spec.add_dependency 'equalizer', '~> 0.0.11'
-  spec.add_dependency 'http', '~> 3.0'
+  spec.add_dependency 'http', '~> 3.3'
   spec.add_dependency 'http-form_data', '~> 2.0'
   spec.add_dependency 'http_parser.rb', '~> 0.6.0'
   spec.add_dependency 'memoizable', '~> 0.4.0'


### PR DESCRIPTION
During the usage of this gem I've decided to record a response with VCR and test it with RSpec. However I've encountered a strange issue: the spec took to long to finish and after that I got a request timeout. Outside of VCR it works fine and gets a proper response.
```
  response:
    status:
      code: 408
      message: Request Timeout
```
Other people have this issue too, it is described in VCR repository https://github.com/vcr/vcr/issues/702. 

I thought that it is related to http.rb gem and updated the dependency to actual version in this PR. It helps me to solve the problem and now twitter gem works like a charm even with VCR.