### PR TITLE
Add create_direct_message_event method

### DIFF
--- a/lib/twitter/rest/direct_messages.rb
+++ b/lib/twitter/rest/direct_messages.rb
@@ -147,6 +147,27 @@ module Twitter
       alias d create_direct_message
       alias m create_direct_message
       alias dm create_direct_message
+
+      # Create a new direct message event to the specified user from the authenticating user
+      #
+      # @see https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event
+      # @note This method requires an access token with RWD (read, write & direct message) permissions. Consult The Application Permission Model for more information.
+      # @rate_limited Yes
+      # @authentication Requires user context
+      # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
+      # @return [Twitter::DirectMessageEvent] The created direct message event.
+      # @param user [Integer, String, Twitter::User] A Twitter user ID, screen name, URI, or object.
+      # @param text [String] The text of your direct message, up to 10,000 characters.
+      # @param options [Hash] A customizable set of options.
+      def create_direct_message_event(*args)
+        arguments = Twitter::Arguments.new(args)
+        options = arguments.options.dup
+        if arguments.length >= 2
+          options[:event] = {type: 'message_create', message_create: {target: {recipient_id: extract_id(arguments[0])}, message_data: {text: arguments[1]}}}
+        end
+        response = Twitter::REST::Request.new(self, :json_post, '/1.1/direct_messages/events/new.json', options).perform
+        Twitter::DirectMessageEvent.new(response[:event])
+      end
     end
   end
 end

--- a/spec/fixtures/direct_message_event.json
+++ b/spec/fixtures/direct_message_event.json
@@ -1,0 +1,1 @@
+{"event":{"type":"message_create","id":"1006278767680131076","created_timestamp":"1528750528627","message_create":{"target":{"recipient_id":"58983"},"sender_id":"124294236","message_data":{"text":"testing","entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[]}}}}}

--- a/spec/twitter/rest/direct_messages_spec.rb
+++ b/spec/twitter/rest/direct_messages_spec.rb
@@ -146,4 +146,19 @@ describe Twitter::REST::DirectMessages do
       end
     end
   end
+
+  describe '#create_direct_message_event' do
+    before do
+      stub_post('/1.1/direct_messages/events/new.json').with(body: {event: {type: 'message_create', message_create: {target: {recipient_id: 58_983}, message_data: {text: 'testing'}}}}).to_return(body: fixture('direct_message_event.json'), headers: {content_type: 'application/json; charset=utf-8'})
+    end
+    it 'requests the correct resource' do
+      @client.create_direct_message_event(58_983, 'testing')
+      expect(a_post('/1.1/direct_messages/events/new.json').with(body: {event: {type: 'message_create', message_create: {target: {recipient_id: 58_983}, message_data: {text: 'testing'}}}})).to have_been_made
+    end
+    it 'returns the sent message' do
+      direct_message_event = @client.create_direct_message_event(58_983, 'testing')
+      expect(direct_message_event).to be_a Twitter::DirectMessageEvent
+      expect(direct_message_event.direct_message.text).to eq('testing')
+    end
+  end
 end


### PR DESCRIPTION
@sferik Here's a create method to go along with the list method, it would be great if we could add this to the next release.

btw, the rubocop rules from the cli are wanting trailing commas, while codeclimate doesn't want them.