### PR TITLE
Add info to search doc

### DIFF
--- a/lib/twitter/rest/search.rb
+++ b/lib/twitter/rest/search.rb
@@ -25,6 +25,7 @@ module Twitter
       # @option options [Integer] :since_id Returns results with an ID greater than (that is, more recent than) the specified ID. There are limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has occured since the since_id, the since_id will be forced to the oldest ID available.
       # @option options [Integer] :max_id Returns results with an ID less than (that is, older than) or equal to the specified ID.
       # @option options [Boolean] :include_entities The entities node will be disincluded when set to false.
+      # @option options [String] :tweet_mode The entities node will truncate or not tweet text. Options are "compat" and "extended". The current default is "compat" (truncate).
       # @return [Twitter::SearchResults] Return tweets that match a specified query with search metadata
       def search(query, options = {})
         options = options.dup


### PR DESCRIPTION
- Motivation:
I was trying to use search tweet and I was getting tweets with truncate value, I found that twitter has updated the API and included a value `tweet_mode` that can get full tweet text.

To avoid another one have the same problem looking how to get full text I added the info on method comment.

[Doc Reference](https://developer.twitter.com/en/docs/tweets/tweet-updates)