### PR TITLE
Add 420 error

### DIFF
--- a/lib/twitter/error.rb
+++ b/lib/twitter/error.rb
@@ -81,6 +81,7 @@ module Twitter
       404 => Twitter::Error::NotFound,
       406 => Twitter::Error::NotAcceptable,
       413 => Twitter::Error::RequestEntityTooLarge,
+      420 => Twitter::Error::TooManyRequests,
       422 => Twitter::Error::UnprocessableEntity,
       429 => Twitter::Error::TooManyRequests,
       500 => Twitter::Error::InternalServerError,


### PR DESCRIPTION
Twitter returns the 420 status code when exceeding the connection limit for a user when using the Streaming API.

Fixes #930