### PR TITLE
add media_category to make image upload return 'media_key'

### DIFF
--- a/lib/twitter/rest/upload_utils.rb
+++ b/lib/twitter/rest/upload_utils.rb
@@ -11,7 +11,7 @@ module Twitter
       # @see https://developer.twitter.com/en/docs/media/upload-media/uploading-media/media-best-practices
       def upload(media, media_category_prefix: "tweet")
         return chunk_upload(media, "video/mp4", "#{media_category_prefix}_video") if File.extname(media) == ".mp4"
-        return chunk_upload(media, "image/gif", "#{media_category_prefix}_gif") if File.extname(media) == ".gif" && File.size(media) > 5_000_000
+        return chunk_upload(media, "image/gif", "#{media_category_prefix}_gif") if File.extname(media) == ".gif"
 
         Twitter::REST::Request.new(self, :multipart_post, "https://upload.twitter.com/1.1/media/upload.json", key: :media, file: media, media_category: "#{media_category_prefix}_image").perform
       end

--- a/lib/twitter/rest/upload_utils.rb
+++ b/lib/twitter/rest/upload_utils.rb
@@ -13,7 +13,7 @@ module Twitter
         return chunk_upload(media, "video/mp4", "#{media_category_prefix}_video") if File.extname(media) == ".mp4"
         return chunk_upload(media, "image/gif", "#{media_category_prefix}_gif") if File.extname(media) == ".gif" && File.size(media) > 5_000_000
 
-        Twitter::REST::Request.new(self, :multipart_post, "https://upload.twitter.com/1.1/media/upload.json", key: :media, file: media).perform
+        Twitter::REST::Request.new(self, :multipart_post, "https://upload.twitter.com/1.1/media/upload.json", key: :media, file: media, media_category: "#{media_category_prefix}_image").perform
       end
 
       # @raise [Twitter::Error::TimeoutError] Error raised when the upload is longer than the value specified in Twitter::Client#timeouts[:upload].


### PR DESCRIPTION
## Description

As explained in https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-upload

> This endpoint returns a media_id by default and can optionally return a media_key when a media_category is specified. These values are used by Twitter endpoints that accept images.

We need to specify 'media_category' parameter to make the `media/upload` endpoint return 'media_key'.
'media_key' is required when using media in Twitter Ads API.

## Testing

```ruby
irb(main):049:0> Twitter::REST::Request.new(v1, :multipart_post, 'https://upload.twitter.com/1.1/media/upload.json', key: :media, file: tempfile, media_type: 'image/png', media_category: 'tweet_image').perform
=> {:media_id=>***, :media_id_string=>"***", :media_key=>"***", :size=>61702, :expires_after_secs=>86400, :image=>{:image_type=>"image/png", :w=>214, :h=>214}}
irb(main):050:0> Twitter::REST::Request.new(v1, :multipart_post, 'https://upload.twitter.com/1.1/media/upload.json', key: :media, file: tempfile, media_type: 'image/png').perform
=> {:media_id=>***, :media_id_string=>"***", :size=>61702, :expires_after_secs=>86400, :image=>{:image_type=>"image/png", :w=>214, :h=>214}}
```